### PR TITLE
Use APL for pets and targets, and make cast failure behavior consistent

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -47,7 +47,7 @@ message APLListItem {
     APLAction action = 3; // The action to be performed.
 }
 
-// NextIndex: 19
+// NextIndex: 20
 message APLAction {
     APLValue condition = 1; // If set, action will only execute if value is true or != 0.
 
@@ -76,8 +76,11 @@ message APLAction {
         APLActionTriggerICD trigger_icd = 11;
         APLActionItemSwap item_swap = 17;
 
-	// Class or Spec-specific actions
-	APLActionCatOptimalRotationAction cat_optimal_rotation_action = 18;
+        // Class or Spec-specific actions
+        APLActionCatOptimalRotationAction cat_optimal_rotation_action = 18;
+
+        // Internal use only, not exposed in UI.
+        APLActionCustomRotation custom_rotation = 19;
     }
 }
 
@@ -275,6 +278,9 @@ message APLActionCatOptimalRotationAction {
     bool use_bite = 7;
     float bite_time = 8;
     bool flower_weave = 9;
+}
+
+message APLActionCustomRotation {
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sim/common/wotlk/nibelung.go
+++ b/sim/common/wotlk/nibelung.go
@@ -1,9 +1,10 @@
 package wotlk
 
 import (
+	"time"
+
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/stats"
-	"time"
 )
 
 var valkyrStats = stats.Stats{
@@ -71,12 +72,8 @@ func (valkyr *ValkyrPet) Initialize() {}
 
 func (valkyr *ValkyrPet) Reset(_ *core.Simulation) {}
 
-func (valkyr *ValkyrPet) OnGCDReady(sim *core.Simulation) {
-	target := valkyr.CurrentTarget
-
-	if valkyr.smite.CanCast(sim, target) {
-		valkyr.smite.Cast(sim, target)
-	}
+func (valkyr *ValkyrPet) ExecuteCustomRotation(sim *core.Simulation) {
+	valkyr.smite.Cast(sim, valkyr.CurrentTarget)
 }
 
 func (valkyr *ValkyrPet) GetPet() *core.Pet {

--- a/sim/core/agent.go
+++ b/sim/core/agent.go
@@ -47,6 +47,10 @@ type Agent interface {
 	// Should return nil when the config doesn't match any custom behaviors.
 	NewAPLValue(rot *APLRotation, config *proto.APLValue) APLValue
 	NewAPLAction(rot *APLRotation, config *proto.APLAction) APLActionImpl
+
+	// Implements custom rotation behavior. Usually for pets and targets but can be used
+	// for players too.
+	ExecuteCustomRotation(sim *Simulation)
 }
 
 type ActionID struct {

--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -53,6 +53,19 @@ func (rot *APLRotation) doAndRecordWarnings(warningsList *[]string, isPrepull bo
 	rot.parsingPrepull = false
 }
 
+func (unit *Unit) newCustomRotation() *APLRotation {
+	return unit.newAPLRotation(&proto.APLRotation{
+		Type: proto.APLRotation_TypeAPL,
+		PriorityList: []*proto.APLListItem{
+			{
+				Action: &proto.APLAction{
+					Action: &proto.APLAction_CustomRotation{},
+				},
+			},
+		},
+	})
+}
+
 func (unit *Unit) newAPLRotation(config *proto.APLRotation) *APLRotation {
 	if config == nil || !unit.IsUsingAPL {
 		return nil

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -132,7 +132,7 @@ func (rot *APLRotation) newAPLActionImpl(config *proto.APLAction) APLActionImpl 
 		return nil
 	}
 
-	customAction := rot.unit.Env.Raid.GetPlayerFromUnit(rot.unit).NewAPLAction(rot, config)
+	customAction := rot.unit.Env.GetAgentFromUnit(rot.unit).NewAPLAction(rot, config)
 	if customAction != nil {
 		return customAction
 	}
@@ -177,6 +177,10 @@ func (rot *APLRotation) newAPLActionImpl(config *proto.APLAction) APLActionImpl 
 		return rot.newActionTriggerICD(config.GetTriggerIcd())
 	case *proto.APLAction_ItemSwap:
 		return rot.newActionItemSwap(config.GetItemSwap())
+
+	case *proto.APLAction_CustomRotation:
+		return rot.newActionCustomRotation(config.GetCustomRotation())
+
 	default:
 		return nil
 	}

--- a/sim/core/apl_value.go
+++ b/sim/core/apl_value.go
@@ -56,7 +56,7 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		return nil
 	}
 
-	customValue := rot.unit.Env.Raid.GetPlayerFromUnit(rot.unit).NewAPLValue(rot, config)
+	customValue := rot.unit.Env.GetAgentFromUnit(rot.unit).NewAPLValue(rot, config)
 	if customValue != nil {
 		return customValue
 	}

--- a/sim/core/environment.go
+++ b/sim/core/environment.go
@@ -148,6 +148,9 @@ func (env *Environment) finalize(raidProto *proto.Raid, _ *proto.Encounter, raid
 
 	for _, target := range env.Encounter.Targets {
 		target.finalize()
+		if target.AI != nil {
+			target.Rotation = target.newCustomRotation()
+		}
 	}
 
 	for _, party := range env.Raid.Parties {
@@ -156,6 +159,7 @@ func (env *Environment) finalize(raidProto *proto.Raid, _ *proto.Encounter, raid
 			character.Finalize()
 			for _, pet := range character.Pets {
 				pet.Finalize()
+				pet.Rotation = pet.newCustomRotation()
 			}
 		}
 	}
@@ -256,6 +260,20 @@ func (env *Environment) NextTarget(target *Unit) *Target {
 }
 func (env *Environment) NextTargetUnit(target *Unit) *Unit {
 	return &env.NextTarget(target).Unit
+}
+func (env *Environment) GetAgentFromUnit(unit *Unit) Agent {
+	raidAgent := env.Raid.GetPlayerFromUnit(unit)
+	if raidAgent != nil {
+		return raidAgent
+	}
+
+	for _, target := range env.Encounter.Targets {
+		if unit == &target.Unit {
+			return target
+		}
+	}
+
+	return nil
 }
 
 func (env *Environment) GetUnit(ref *proto.UnitReference, contextUnit *Unit) *Unit {

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -62,6 +62,7 @@ func NewPet(name string, owner *Character, baseStats stats.Stats, statInheritanc
 				PseudoStats: stats.NewPseudoStats(),
 				auraTracker: newAuraTracker(),
 				Metrics:     NewUnitMetrics(),
+				IsUsingAPL:  true,
 
 				StatDependencyManager: stats.NewStatDependencyManager(),
 			},
@@ -268,3 +269,4 @@ func (pet *Pet) GetCharacter() *Character {
 func (pet *Pet) AddRaidBuffs(_ *proto.RaidBuffs)   {}
 func (pet *Pet) AddPartyBuffs(_ *proto.PartyBuffs) {}
 func (pet *Pet) ApplyTalents()                     {}
+func (pet *Pet) OnGCDReady(_ *Simulation)          {}

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -155,6 +155,7 @@ func NewTarget(options *proto.Target, targetIndex int32) *Target {
 	preset := GetPresetTargetWithID(options.Id)
 	if preset != nil && preset.AI != nil {
 		target.AI = preset.AI()
+		target.IsUsingAPL = true
 	}
 
 	return target

--- a/sim/core/target_ai.go
+++ b/sim/core/target_ai.go
@@ -1,15 +1,15 @@
 package core
 
 import (
-	"fmt"
-	"github.com/wowsims/wotlk/sim/core/proto"
 	"log"
+
+	"github.com/wowsims/wotlk/sim/core/proto"
 )
 
 type TargetAI interface {
 	Initialize(*Target, *proto.Target)
 	Reset(*Simulation)
-	DoAction(*Simulation)
+	ExecuteCustomRotation(*Simulation)
 }
 
 func (target *Target) initialize(config *proto.Target) {
@@ -44,15 +44,7 @@ func (target *Target) initialize(config *proto.Target) {
 		target.gcdAction = &PendingAction{
 			Priority: ActionPriorityGCD,
 			OnAction: func(sim *Simulation) {
-				if target.GCD.IsReady(sim) {
-					target.OnGCDReady(sim)
-
-					if !target.doNothing && target.GCD.IsReady(sim) && (!target.IsWaiting() && !target.IsWaitingForMana()) {
-						msg := fmt.Sprintf("Target `%s` did not perform any actions. Either this is a bug or agent should use 'WaitUntil' or 'WaitForMana' to explicitly wait.\n\tIf character has no action to perform use 'DoNothing'.", target.Label)
-						panic(msg)
-					}
-					target.doNothing = false
-				}
+				target.Rotation.DoNextAction(sim)
 			},
 		}
 	}
@@ -69,16 +61,11 @@ func (target *Target) DoNothing() {
 	target.doNothing = true
 }
 
-func (target *Target) OnAutoAttack(sim *Simulation, _ *Spell) {
-	if target.GCD.IsReady(sim) {
-		if target.AI != nil {
-			target.AI.DoAction(sim)
-		}
-	}
-}
-func (target *Target) OnGCDReady(sim *Simulation) {
+func (target *Target) OnAutoAttack(sim *Simulation, _ *Spell) {}
+func (target *Target) OnGCDReady(sim *Simulation)             {}
+func (target *Target) ExecuteCustomRotation(sim *Simulation) {
 	if target.AI != nil {
-		target.AI.DoAction(sim)
+		target.AI.ExecuteCustomRotation(sim)
 	}
 }
 

--- a/sim/core/target_dummy.go
+++ b/sim/core/target_dummy.go
@@ -52,3 +52,4 @@ func (td *TargetDummy) OnGCDReady(sim *Simulation) {
 	td.DoNothing()
 }
 func (td *TargetDummy) OnAutoAttack(sim *Simulation, spell *Spell) {}
+func (td *TargetDummy) ExecuteCustomRotation(sim *Simulation)      {}

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -567,3 +567,7 @@ func (unit *Unit) DoneAPLLoop(sim *Simulation, usedGCD bool) {
 		unit.ManaRequired = 0
 	}
 }
+
+func (unit *Unit) ExecuteCustomRotation(sim *Simulation) {
+	panic("Unimplemented ExecuteCustomRotation")
+}

--- a/sim/deathknight/bloodworm_pet.go
+++ b/sim/deathknight/bloodworm_pet.go
@@ -57,7 +57,7 @@ func (bloodworm *BloodwormPet) Initialize() {
 func (bloodworm *BloodwormPet) Reset(_ *core.Simulation) {
 }
 
-func (bloodworm *BloodwormPet) OnGCDReady(_ *core.Simulation) {
+func (bloodworm *BloodwormPet) ExecuteCustomRotation(_ *core.Simulation) {
 }
 
 func (bloodworm *BloodwormPet) enable(sim *core.Simulation) {

--- a/sim/deathknight/dancing_rune_weapon.go
+++ b/sim/deathknight/dancing_rune_weapon.go
@@ -192,9 +192,7 @@ func (runeWeapon *RuneWeaponPet) GetPet() *core.Pet {
 func (runeWeapon *RuneWeaponPet) Reset(_ *core.Simulation) {
 }
 
-func (runeWeapon *RuneWeaponPet) OnGCDReady(_ *core.Simulation) {
-	// No GCD system on Rune Weapon
-	runeWeapon.DoNothing()
+func (runeWeapon *RuneWeaponPet) ExecuteCustomRotation(_ *core.Simulation) {
 }
 
 func (runeWeapon *RuneWeaponPet) enable(sim *core.Simulation) {

--- a/sim/deathknight/dps/TestBlood.results
+++ b/sim/deathknight/dps/TestBlood.results
@@ -46,956 +46,956 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10677.20213
-  tps: 5364.85589
+  dps: 10642.47211
+  tps: 5334.83572
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10412.14153
-  tps: 5280.10343
+  dps: 10393.84127
+  tps: 5261.02303
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10196.88184
-  tps: 5162.48222
+  dps: 10166.90957
+  tps: 5136.67549
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10196.88184
-  tps: 5162.48222
+  dps: 10166.90957
+  tps: 5136.67549
   hps: 94.38579
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10699.42508
-  tps: 5376.43212
+  dps: 10669.4591
+  tps: 5350.09937
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10184.61264
-  tps: 5120.31809
+  dps: 10167.43236
+  tps: 5108.98214
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8056.94799
-  tps: 4059.34545
+  dps: 8056.91808
+  tps: 4065.44515
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8031.07925
-  tps: 4048.49411
+  dps: 7960.00011
+  tps: 4038.11649
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 7688.35705
-  tps: 3868.26738
+  dps: 7662.35239
+  tps: 3859.04943
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5254.34368
+  dps: 10636.21801
+  tps: 5224.94247
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12547.83462
-  tps: 6412.47935
+  dps: 12371.37937
+  tps: 6306.89181
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12672.49654
-  tps: 6485.89847
+  dps: 12500.78395
+  tps: 6384.96892
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 10892.42012
-  tps: 5480.7557
+  dps: 10860.58838
+  tps: 5452.90139
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
   hps: 64
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10359.03902
-  tps: 5247.20415
+  dps: 10316.39633
+  tps: 5213.96405
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10416.63644
-  tps: 5283.83939
+  dps: 10384.49471
+  tps: 5254.1991
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10477.29457
-  tps: 5280.8955
+  dps: 10447.47552
+  tps: 5254.59137
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9004.45904
-  tps: 4547.23708
+  dps: 8975.42779
+  tps: 4529.17426
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkrunedPlate"
  value: {
-  dps: 7924.72528
-  tps: 3992.97909
+  dps: 7890.75432
+  tps: 3970.16865
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10303.1279
-  tps: 5217.34852
+  dps: 10266.42122
+  tps: 5188.56715
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10887.5384
-  tps: 5555.79003
+  dps: 10884.80591
+  tps: 5547.95077
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10929.18228
-  tps: 5572.0838
+  dps: 10908.04513
+  tps: 5555.863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10215.0467
-  tps: 5171.9802
+  dps: 10185.01025
+  tps: 5146.1235
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10704.31664
-  tps: 5379.36706
+  dps: 10674.293
+  tps: 5352.71457
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 10569.11157
-  tps: 5363.48859
+  dps: 10503.44963
+  tps: 5321.39989
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10477.31836
-  tps: 5317.45449
+  dps: 10465.31904
+  tps: 5302.73109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10699.42508
-  tps: 5376.43212
+  dps: 10669.4591
+  tps: 5350.09937
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10694.24589
-  tps: 5373.65091
+  dps: 10659.89398
+  tps: 5344.74622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10359.32756
-  tps: 5231.60564
+  dps: 10345.47014
+  tps: 5223.88207
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10408.20577
-  tps: 5277.25111
+  dps: 10380.21361
+  tps: 5253.04952
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10349.60742
-  tps: 5243.31458
+  dps: 10306.6632
+  tps: 5209.79458
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10314.64331
-  tps: 5224.52425
+  dps: 10274.88829
+  tps: 5193.40189
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10427.73647
-  tps: 5285.60611
+  dps: 10396.83042
+  tps: 5259.10135
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10393.73074
-  tps: 5270.38121
+  dps: 10349.83238
+  tps: 5234.19722
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10699.42508
-  tps: 5376.43212
+  dps: 10669.4591
+  tps: 5350.09937
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10694.24589
-  tps: 5373.65091
+  dps: 10659.89398
+  tps: 5344.74622
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10432.26857
-  tps: 5294.93286
+  dps: 10400.11541
+  tps: 5267.74575
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10702.60343
-  tps: 5378.12872
-  hps: 16.54901
+  dps: 10667.77441
+  tps: 5348.03191
+  hps: 16.16919
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50179"
  value: {
-  dps: 12256.01633
-  tps: 6240.00452
+  dps: 12202.49811
+  tps: 6201.83029
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 12326.22266
-  tps: 6279.10307
+  dps: 12272.95951
+  tps: 6241.03771
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10505.87147
-  tps: 5322.2231
+  dps: 10511.90088
+  tps: 5321.56172
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10539.11778
-  tps: 5321.08899
+  dps: 10503.18229
+  tps: 5297.61651
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10208.63132
-  tps: 5168.62542
+  dps: 10178.61752
+  tps: 5142.78636
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10696.56917
-  tps: 5374.97566
+  dps: 10661.76366
+  tps: 5344.89706
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10702.60343
-  tps: 5378.12872
+  dps: 10667.77441
+  tps: 5348.03191
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10245.66944
-  tps: 5187.99368
+  dps: 10215.52485
+  tps: 5162.05279
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10251.95651
-  tps: 5191.28136
+  dps: 10221.78972
+  tps: 5165.32319
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10275.16889
-  tps: 5210.2437
+  dps: 10235.17317
+  tps: 5177.90342
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10283.42781
-  tps: 5215.19905
+  dps: 10243.45846
+  tps: 5182.8746
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 10883.07991
-  tps: 5475.48064
+  dps: 10846.59522
+  tps: 5444.89714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 8558.22114
-  tps: 4295.89574
+  dps: 8550.83422
+  tps: 4283.7588
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScourgebornePlate"
  value: {
-  dps: 7892.2371
-  tps: 3961.61447
+  dps: 7853.1942
+  tps: 3934.58714
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 10548.76028
-  tps: 5399.47252
+  dps: 10520.60458
+  tps: 5377.77362
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 8658.45895
-  tps: 4358.14018
+  dps: 8583.43832
+  tps: 4306.70105
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10214.37715
-  tps: 5171.34109
+  dps: 10184.26736
+  tps: 5145.4346
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 13761.54085
-  tps: 7071.03671
+  dps: 13783.42493
+  tps: 7074.428
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10353.2974
-  tps: 5245.24628
+  dps: 10310.37201
+  tps: 5211.5676
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofLife-37657"
  value: {
-  dps: 10298.96183
-  tps: 5216.46316
+  dps: 10371.41099
+  tps: 5257.67147
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10311.18438
-  tps: 5212.33296
+  dps: 10283.25615
+  tps: 5184.1897
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StormshroudArmor"
  value: {
-  dps: 7624.88629
-  tps: 3844.48464
+  dps: 7633.0556
+  tps: 3851.65611
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10702.60343
-  tps: 5378.12872
+  dps: 10667.77441
+  tps: 5348.03191
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10696.56917
-  tps: 5374.97566
+  dps: 10661.76366
+  tps: 5344.89706
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10686.00922
-  tps: 5369.45782
+  dps: 10651.24487
+  tps: 5339.41107
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9114.01328
-  tps: 4586.44334
+  dps: 9163.32538
+  tps: 4620.11108
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8104.33637
-  tps: 4069.5673
+  dps: 8073.08418
+  tps: 4042.18526
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 8815.93629
-  tps: 4355.22822
+  dps: 8737.61896
+  tps: 4316.58654
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10751.69659
-  tps: 5394.91031
+  dps: 10727.04005
+  tps: 5382.69793
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10430.79789
-  tps: 5303.37051
+  dps: 10491.50384
+  tps: 5330.53592
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10503.18755
-  tps: 5338.80597
+  dps: 10510.67484
+  tps: 5335.96757
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10227.49322
-  tps: 5160.56887
+  dps: 10247.61895
+  tps: 5166.18252
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10670.92357
-  tps: 5361.57518
+  dps: 10636.21801
+  tps: 5331.57395
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 7991.80399
-  tps: 4030.18482
+  dps: 7912.79014
+  tps: 3993.22907
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7756.78696
-  tps: 3749.47786
+  dps: 7759.29716
+  tps: 3753.28464
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10196.86979
-  tps: 5162.47499
+  dps: 10166.89753
+  tps: 5136.66827
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 10969.31046
-  tps: 5526.63009
+  dps: 10965.78046
+  tps: 5526.1945
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32239.31723
-  tps: 16557.73023
+  dps: 32306.08553
+  tps: 16591.95837
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10770.97441
-  tps: 5462.5519
+  dps: 10738.33642
+  tps: 5434.52548
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13845.82552
-  tps: 6288.7892
+  dps: 13918.48548
+  tps: 6321.56253
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17359.01949
-  tps: 8920.8456
+  dps: 17399.49906
+  tps: 8943.23299
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6230.87833
-  tps: 3170.4907
+  dps: 6269.69442
+  tps: 3195.29518
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7271.43018
-  tps: 3261.52028
+  dps: 7280.58993
+  tps: 3271.89478
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_dps-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28139.90638
-  tps: 15108.50144
+  dps: 28055.98211
+  tps: 15052.07508
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_dps-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10799.86524
-  tps: 5457.71051
+  dps: 10839.69606
+  tps: 5490.33632
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_dps-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14071.67977
-  tps: 6364.68779
+  dps: 14150.36846
+  tps: 6414.06121
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_dps-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14150.92248
-  tps: 7833.97981
+  dps: 14120.02417
+  tps: 7811.89183
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_dps-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6238.76131
-  tps: 3166.87838
+  dps: 6275.18308
+  tps: 3183.59544
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Human-p3_blood-Basic-blood_dps-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7462.83055
-  tps: 3351.28085
+  dps: 7499.90666
+  tps: 3377.91751
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 32658.0051
-  tps: 16635.95539
+  dps: 32724.0174
+  tps: 16670.05424
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 10892.42012
-  tps: 5480.7557
+  dps: 10860.58838
+  tps: 5452.90139
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14104.09677
-  tps: 6340.94105
+  dps: 14178.48498
+  tps: 6373.7154
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 17598.75643
-  tps: 8968.30415
+  dps: 17638.37877
+  tps: 8990.39159
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6302.04226
-  tps: 3181.89866
+  dps: 6339.51831
+  tps: 3206.2441
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7408.82968
-  tps: 3289.72785
+  dps: 7417.75717
+  tps: 3300.06824
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_dps-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28379.47981
-  tps: 15149.37461
+  dps: 28295.15804
+  tps: 15091.65994
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_dps-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10922.48275
-  tps: 5475.95425
+  dps: 10959.55226
+  tps: 5507.73381
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_dps-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14322.42988
-  tps: 6412.37915
+  dps: 14397.34992
+  tps: 6459.27656
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_dps-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14237.94211
-  tps: 7850.23063
+  dps: 14206.10525
+  tps: 7826.95227
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_dps-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6308.28269
-  tps: 3177.31227
+  dps: 6346.32581
+  tps: 3194.61819
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3_blood-Basic-blood_dps-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7597.49472
-  tps: 3378.5377
+  dps: 7634.46245
+  tps: 3405.15469
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10511.98796
-  tps: 5314.70021
+  dps: 10494.34362
+  tps: 5305.80541
  }
 }

--- a/sim/deathknight/dps/TestFrost.results
+++ b/sim/deathknight/dps/TestFrost.results
@@ -46,908 +46,908 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11015.93963
-  tps: 6452.9445
+  dps: 11016.0262
+  tps: 6452.37568
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10975.86284
-  tps: 6428.15015
+  dps: 10974.34865
+  tps: 6427.76442
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10779.04798
-  tps: 6310.8095
-  hps: 64.65047
+  dps: 10780.75828
+  tps: 6311.21493
+  hps: 64.67422
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10779.04798
-  tps: 6310.8095
-  hps: 64.65047
+  dps: 10780.75828
+  tps: 6311.21493
+  hps: 64.67422
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11031.54265
-  tps: 6462.3063
+  dps: 11031.95442
+  tps: 6461.93261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10643.48451
-  tps: 6240.95689
+  dps: 10655.61888
+  tps: 6247.78935
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8731.35167
-  tps: 5114.25345
+  dps: 8748.12991
+  tps: 5124.87878
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8610.82718
-  tps: 5046.41668
+  dps: 8622.30564
+  tps: 5053.69229
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8292.83706
-  tps: 4855.82562
+  dps: 8283.1547
+  tps: 4850.27464
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6319.63225
+  dps: 11008.79081
+  tps: 6319.07376
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 11298.5133
-  tps: 6622.4887
+  dps: 11298.26197
+  tps: 6621.71714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 11298.5133
-  tps: 6622.4887
+  dps: 11298.26197
+  tps: 6621.71714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11305.64843
-  tps: 6626.76977
+  dps: 11306.13975
+  tps: 6626.44382
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10925.17165
-  tps: 6398.48371
+  dps: 10924.96265
+  tps: 6397.73755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10965.28097
-  tps: 6421.77472
+  dps: 10974.69283
+  tps: 6427.88706
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11016.27527
-  tps: 6442.91654
+  dps: 11017.56348
+  tps: 6442.99606
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9560.87455
-  tps: 5600.8349
+  dps: 9548.97274
+  tps: 5594.2633
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkrunedPlate"
  value: {
-  dps: 8521.63719
-  tps: 4984.86556
+  dps: 8517.28778
+  tps: 4982.40705
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 10726.96724
-  tps: 6279.56106
+  dps: 10728.87082
+  tps: 6280.08246
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10898.70824
-  tps: 6382.60566
+  dps: 10898.7221
+  tps: 6381.99323
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11433.74353
-  tps: 6696.03903
+  dps: 11426.29275
+  tps: 6690.42558
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11493.54749
-  tps: 6734.47681
+  dps: 11492.93115
+  tps: 6733.56684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10799.18348
-  tps: 6322.89081
+  dps: 10800.85077
+  tps: 6323.27043
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11035.7031
-  tps: 6464.80258
+  dps: 11036.15597
+  tps: 6464.45355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11054.58588
-  tps: 6470.59956
+  dps: 11053.10579
+  tps: 6470.06558
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11001.03092
-  tps: 6437.82133
+  dps: 11002.13452
+  tps: 6438.60695
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11031.54265
-  tps: 6462.3063
+  dps: 11031.95442
+  tps: 6461.93261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11025.55162
-  tps: 6458.71169
+  dps: 11025.25043
+  tps: 6457.91022
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10908.43145
-  tps: 6377.72463
+  dps: 10917.69514
+  tps: 6383.8164
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10953.16919
-  tps: 6415.65686
+  dps: 10966.05354
+  tps: 6422.80671
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10914.7931
-  tps: 6392.25658
+  dps: 10915.58135
+  tps: 6392.10878
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10893.93139
-  tps: 6379.73955
+  dps: 10893.92656
+  tps: 6379.1159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 10727.85759
-  tps: 6280.09527
+  dps: 10729.76118
+  tps: 6280.61667
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11025.00355
-  tps: 6458.38284
+  dps: 11026.84636
+  tps: 6458.86778
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10946.18019
-  tps: 6410.14602
+  dps: 10931.09962
+  tps: 6400.84364
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 10724.9853
-  tps: 6278.37189
+  dps: 10726.88888
+  tps: 6278.89329
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11031.54265
-  tps: 6462.3063
+  dps: 11031.95442
+  tps: 6461.93261
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11025.55162
-  tps: 6458.71169
+  dps: 11025.25043
+  tps: 6457.91022
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11017.84717
-  tps: 6454.08902
+  dps: 11019.46504
+  tps: 6454.43899
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11042.08862
-  tps: 6468.63389
+  dps: 11042.19088
+  tps: 6468.07449
   hps: 16.93247
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 11298.5133
-  tps: 6622.4887
+  dps: 11298.26197
+  tps: 6621.71714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 11298.5133
-  tps: 6622.4887
+  dps: 11298.26197
+  tps: 6621.71714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11036.47299
-  tps: 6462.74807
+  dps: 11026.57626
+  tps: 6456.65754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10942.14635
-  tps: 6408.66853
+  dps: 10944.82572
+  tps: 6409.65539
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10792.09736
-  tps: 6318.63914
+  dps: 10793.76219
+  tps: 6319.01728
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11035.73003
-  tps: 6464.81873
+  dps: 11035.82896
+  tps: 6464.25734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11042.08862
-  tps: 6468.63389
+  dps: 11042.19088
+  tps: 6468.07449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10833.00788
-  tps: 6343.18544
+  dps: 10834.68695
+  tps: 6343.57213
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10839.95227
-  tps: 6347.35208
+  dps: 10841.63376
+  tps: 6347.74022
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10801.33095
-  tps: 6325.24688
+  dps: 10783.77238
+  tps: 6314.41792
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10803.12244
-  tps: 6326.32177
+  dps: 10785.64471
+  tps: 6315.54132
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11298.5133
-  tps: 6622.4887
+  dps: 11298.26197
+  tps: 6621.71714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 10728.89633
-  tps: 6280.71852
+  dps: 10730.79992
+  tps: 6281.23991
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 10724.7057
-  tps: 6278.20413
+  dps: 10726.60928
+  tps: 6278.72553
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9340.24726
-  tps: 5474.05643
+  dps: 9326.39338
+  tps: 5465.72633
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScourgebornePlate"
  value: {
-  dps: 8442.32993
-  tps: 4938.08
+  dps: 8449.83913
+  tps: 4942.66453
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 11275.27565
-  tps: 6622.82409
+  dps: 11280.60389
+  tps: 6626.07159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9283.22664
-  tps: 5430.84556
+  dps: 9277.60549
+  tps: 5427.63857
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10792.62725
-  tps: 6318.95707
+  dps: 10794.2916
+  tps: 6319.33493
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 11298.5133
-  tps: 6622.4887
+  dps: 11298.26197
+  tps: 6621.71714
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 10722.51549
-  tps: 6276.89001
+  dps: 10724.41907
+  tps: 6277.41141
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 10737.48038
-  tps: 6285.86894
+  dps: 10740.2241
+  tps: 6286.89443
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 10722.51549
-  tps: 6276.89001
+  dps: 10724.41907
+  tps: 6277.41141
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 11167.64643
-  tps: 6537.00488
+  dps: 11169.96136
+  tps: 6537.72465
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 10722.51549
-  tps: 6276.89001
+  dps: 10724.41907
+  tps: 6277.41141
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11207.43291
-  tps: 6560.21522
+  dps: 11209.57951
+  tps: 6560.82939
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 10722.51549
-  tps: 6276.89001
+  dps: 10724.41907
+  tps: 6277.41141
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10919.7249
-  tps: 6395.21566
+  dps: 10920.55928
+  tps: 6395.09553
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 10895.45513
-  tps: 6377.41635
+  dps: 10893.26068
+  tps: 6376.18686
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10972.31104
-  tps: 6427.17463
+  dps: 10984.81633
+  tps: 6434.17022
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StormshroudArmor"
  value: {
-  dps: 8253.17307
-  tps: 4833.43464
+  dps: 8257.71202
+  tps: 4836.63697
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11042.08862
-  tps: 6468.63389
+  dps: 11042.19088
+  tps: 6468.07449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11035.73003
-  tps: 6464.81873
+  dps: 11035.82896
+  tps: 6464.25734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11024.6025
-  tps: 6458.14222
+  dps: 11024.69561
+  tps: 6457.57733
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9612.4248
-  tps: 5634.13747
+  dps: 9617.46391
+  tps: 5637.51144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8451.11075
-  tps: 4945.75551
+  dps: 8462.95044
+  tps: 4952.95634
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9309.10368
-  tps: 5440.69645
+  dps: 9312.06171
+  tps: 5444.04669
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11062.39875
-  tps: 6476.90963
+  dps: 11076.53231
+  tps: 6486.58886
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11132.51929
-  tps: 6520.46848
+  dps: 11137.86421
+  tps: 6523.81952
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11115.05429
-  tps: 6511.10869
+  dps: 11095.48167
+  tps: 6499.5293
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10874.30721
-  tps: 6362.25253
+  dps: 10892.42355
+  tps: 6373.65205
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11008.70603
-  tps: 6448.60433
+  dps: 11008.79081
+  tps: 6448.03445
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8631.48295
-  tps: 5059.00188
+  dps: 8628.23897
+  tps: 5057.15295
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 10273.69821
-  tps: 6007.03334
+  dps: 10270.54812
+  tps: 6005.27295
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10779.10615
-  tps: 6310.84441
+  dps: 10780.76645
+  tps: 6311.21984
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 10730.08347
-  tps: 6281.4308
+  dps: 10731.98705
+  tps: 6281.95219
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 11292.14522
-  tps: 6619.99766
+  dps: 11292.66188
+  tps: 6620.35803
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 37796.72143
-  tps: 22532.94179
+  dps: 37776.79898
+  tps: 22520.95779
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11263.22773
-  tps: 6610.2658
+  dps: 11252.59148
+  tps: 6604.23941
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13063.22228
-  tps: 7479.99635
+  dps: 13044.16238
+  tps: 7470.04161
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19322.0766
-  tps: 11501.39054
+  dps: 19311.34584
+  tps: 11494.932
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6804.39685
-  tps: 3988.86985
+  dps: 6808.13227
+  tps: 3991.15729
  }
 }
 dps_results: {
@@ -960,120 +960,120 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31912.0161
-  tps: 18889.51621
+  dps: 31842.12035
+  tps: 18850.37243
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11457.98458
-  tps: 6615.72484
+  dps: 11478.27997
+  tps: 6629.97994
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13772.95199
-  tps: 7369.80275
+  dps: 13770.76102
+  tps: 7372.91086
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16452.53555
-  tps: 9696.82315
+  dps: 16454.15487
+  tps: 9698.42734
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6866.87377
-  tps: 3945.34348
+  dps: 6910.85991
+  tps: 3972.25793
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8084.65682
-  tps: 4254.48034
+  dps: 8141.28816
+  tps: 4288.66566
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26972.71578
-  tps: 15943.8754
+  dps: 26960.51085
+  tps: 15937.65039
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9660.55674
-  tps: 5556.71696
+  dps: 9615.08614
+  tps: 5529.42337
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12939.32869
-  tps: 6907.36578
+  dps: 12771.42301
+  tps: 6807.21142
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13694.91045
-  tps: 8047.48835
+  dps: 13668.55896
+  tps: 8032.1655
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5816.20699
-  tps: 3320.6192
+  dps: 5828.98256
+  tps: 3327.65778
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7437.36658
-  tps: 3873.24672
+  dps: 7375.92218
+  tps: 3836.84135
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--FullBuffs-LongMultiTarget"
  value: {
-  dps: 36936.72925
-  tps: 22019.67298
+  dps: 36936.09369
+  tps: 22019.42903
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11319.95431
-  tps: 6649.49903
+  dps: 11311.24449
+  tps: 6644.20571
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12881.67401
-  tps: 7366.11728
+  dps: 12875.9821
+  tps: 7362.74929
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--NoBuffs-LongMultiTarget"
  value: {
-  dps: 18996.41296
-  tps: 11309.16457
+  dps: 18991.6316
+  tps: 11306.29529
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6835.83954
-  tps: 4012.90255
+  dps: 6837.71826
+  tps: 4013.95033
  }
 }
 dps_results: {
@@ -1086,120 +1086,120 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31912.0161
-  tps: 18889.51621
+  dps: 31842.12035
+  tps: 18850.37243
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11457.98458
-  tps: 6615.72484
+  dps: 11478.27997
+  tps: 6629.97994
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13772.95199
-  tps: 7369.80275
+  dps: 13770.76102
+  tps: 7372.91086
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16452.53555
-  tps: 9696.82315
+  dps: 16454.15487
+  tps: 9698.42734
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6866.87377
-  tps: 3945.34348
+  dps: 6910.85991
+  tps: 3972.25793
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8084.65682
-  tps: 4254.48034
+  dps: 8141.28816
+  tps: 4288.66566
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26972.71578
-  tps: 15943.8754
+  dps: 26960.51085
+  tps: 15937.65039
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9660.55674
-  tps: 5556.71696
+  dps: 9615.08614
+  tps: 5529.42337
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12939.32869
-  tps: 6907.36578
+  dps: 12771.42301
+  tps: 6807.21142
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13694.91045
-  tps: 8047.48835
+  dps: 13668.55896
+  tps: 8032.1655
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5816.20699
-  tps: 3320.6192
+  dps: 5828.98256
+  tps: 3327.65778
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p3_frost-Desync-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7437.36658
-  tps: 3873.24672
+  dps: 7375.92218
+  tps: 3836.84135
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 38320.05463
-  tps: 22837.17434
+  dps: 38347.57041
+  tps: 22853.60844
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11298.5133
-  tps: 6622.4887
+  dps: 11298.26197
+  tps: 6621.71714
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13097.72109
-  tps: 7483.86643
+  dps: 13079.22802
+  tps: 7473.87176
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19315.44787
-  tps: 11491.86087
+  dps: 19300.33845
+  tps: 11482.79775
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6826.00933
-  tps: 3997.97796
+  dps: 6819.74332
+  tps: 3994.30821
  }
 }
 dps_results: {
@@ -1212,120 +1212,120 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31955.43487
-  tps: 18907.92876
+  dps: 31983.47299
+  tps: 18925.12668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11447.63184
-  tps: 6603.14339
+  dps: 11491.21901
+  tps: 6628.95282
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13905.3919
-  tps: 7431.06228
+  dps: 13875.20952
+  tps: 7419.68916
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16527.35578
-  tps: 9737.62766
+  dps: 16509.10896
+  tps: 9727.41449
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6910.67837
-  tps: 3967.04899
+  dps: 6910.84497
+  tps: 3966.82987
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8152.91928
-  tps: 4285.29378
+  dps: 8166.5039
+  tps: 4293.81943
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27028.33524
-  tps: 15970.35576
+  dps: 26952.25454
+  tps: 15926.18686
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9672.37192
-  tps: 5557.05331
+  dps: 9623.98792
+  tps: 5528.38849
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12981.33602
-  tps: 6916.54928
+  dps: 12810.17337
+  tps: 6816.28145
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13712.22782
-  tps: 8053.50348
+  dps: 13692.90527
+  tps: 8042.49341
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5810.28334
-  tps: 3312.39706
+  dps: 5872.37795
+  tps: 3350.03517
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7497.75236
-  tps: 3900.95923
+  dps: 7435.72264
+  tps: 3864.41984
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--FullBuffs-LongMultiTarget"
  value: {
-  dps: 37076.04632
-  tps: 22097.33932
+  dps: 37068.4553
+  tps: 22092.74678
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11345.12005
-  tps: 6657.87403
+  dps: 11354.85419
+  tps: 6663.7153
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13017.38883
-  tps: 7431.12294
+  dps: 13009.48546
+  tps: 7426.73535
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--NoBuffs-LongMultiTarget"
  value: {
-  dps: 19503.81959
-  tps: 11609.71666
+  dps: 19504.57292
+  tps: 11610.13011
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6857.99649
-  tps: 4019.77308
+  dps: 6855.31225
+  tps: 4018.06503
  }
 }
 dps_results: {
@@ -1338,91 +1338,91 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31955.43487
-  tps: 18907.92876
+  dps: 31983.47299
+  tps: 18925.12668
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11447.63184
-  tps: 6603.14339
+  dps: 11491.21901
+  tps: 6628.95282
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13905.3919
-  tps: 7431.06228
+  dps: 13875.20952
+  tps: 7419.68916
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16527.35578
-  tps: 9737.62766
+  dps: 16509.10896
+  tps: 9727.41449
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 6910.67837
-  tps: 3967.04899
+  dps: 6910.84497
+  tps: 3966.82987
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_bl_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8152.91928
-  tps: 4285.29378
+  dps: 8166.5039
+  tps: 4293.81943
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27028.33524
-  tps: 15970.35576
+  dps: 26952.25454
+  tps: 15926.18686
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 9672.37192
-  tps: 5557.05331
+  dps: 9623.98792
+  tps: 5528.38849
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 12981.33602
-  tps: 6916.54928
+  dps: 12810.17337
+  tps: 6816.28145
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13712.22782
-  tps: 8053.50348
+  dps: 13692.90527
+  tps: 8042.49341
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5810.28334
-  tps: 3312.39706
+  dps: 5872.37795
+  tps: 3350.03517
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3_frost-Desync-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7497.75236
-  tps: 3900.95923
+  dps: 7435.72264
+  tps: 3864.41984
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11054.98921
-  tps: 6487.80405
+  dps: 11070.66512
+  tps: 6501.69344
  }
 }

--- a/sim/deathknight/dps/TestFrostUH.results
+++ b/sim/deathknight/dps/TestFrostUH.results
@@ -46,1047 +46,1047 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11167.28412
-  tps: 7960.57412
+  dps: 11172.56006
+  tps: 7964.98254
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10936.28617
-  tps: 7790.23104
+  dps: 10941.57134
+  tps: 7794.63811
   hps: 60.89457
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10936.28617
-  tps: 7790.23104
+  dps: 10941.57134
+  tps: 7794.63811
   hps: 60.89457
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11273.81664
-  tps: 8038.65347
+  dps: 11278.14365
+  tps: 8042.35534
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 10630.31092
-  tps: 7585.79836
+  dps: 10646.79369
+  tps: 7596.44998
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8672.26608
-  tps: 6180.90545
+  dps: 8682.59954
+  tps: 6187.09469
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8660.27309
-  tps: 6180.5624
+  dps: 8650.1024
+  tps: 6172.71254
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8315.58932
-  tps: 5924.04932
+  dps: 8292.82343
+  tps: 5907.09894
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11244.56867
-  tps: 7856.78442
+  dps: 11247.79226
+  tps: 7859.61638
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 11515.829
-  tps: 8216.77456
+  dps: 11519.94323
+  tps: 8220.31982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 11515.829
-  tps: 8216.77456
+  dps: 11519.94323
+  tps: 8220.31982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11523.4493
-  tps: 8222.3831
+  dps: 11528.06075
+  tps: 8226.29432
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
   hps: 42.66667
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11110.04531
-  tps: 7918.11776
+  dps: 11113.32376
+  tps: 7921.0479
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11167.29935
-  tps: 7960.28784
+  dps: 11164.56293
+  tps: 7958.86962
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11203.16336
-  tps: 7966.55
+  dps: 11209.14649
+  tps: 7971.51457
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9782.6248
-  tps: 6976.85324
+  dps: 9766.25772
+  tps: 6964.93913
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DarkrunedPlate"
  value: {
-  dps: 8562.86169
-  tps: 6093.30384
+  dps: 8561.74341
+  tps: 6092.58603
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 10916.76985
-  tps: 7775.86702
+  dps: 10921.98932
+  tps: 7780.22575
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11082.76376
-  tps: 7898.03854
+  dps: 11083.96412
+  tps: 7899.4392
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11650.4725
-  tps: 8300.34064
+  dps: 11653.19447
+  tps: 8302.68387
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11660.11751
-  tps: 8311.99519
+  dps: 11652.11471
+  tps: 8306.82286
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11282.05549
-  tps: 8044.71725
+  dps: 11285.67453
+  tps: 8047.89806
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11179.30689
-  tps: 7954.12011
+  dps: 11175.64155
+  tps: 7952.81672
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11092.15512
-  tps: 7894.5297
+  dps: 11091.02609
+  tps: 7893.96194
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11273.81664
-  tps: 8038.65347
+  dps: 11278.14365
+  tps: 8042.35534
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11268.25378
-  tps: 8034.5592
+  dps: 11272.13533
+  tps: 8037.93321
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10961.33842
-  tps: 7796.07933
+  dps: 10979.30561
+  tps: 7810.94673
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11145.02568
-  tps: 7943.93491
+  dps: 11138.59784
+  tps: 7939.66599
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11092.01402
-  tps: 7904.84673
+  dps: 11095.10109
+  tps: 7907.63601
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11059.81772
-  tps: 7881.15026
+  dps: 11061.53283
+  tps: 7882.92977
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 10918.04643
-  tps: 7776.80659
+  dps: 10923.27064
+  tps: 7781.1688
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11192.32005
-  tps: 7978.67197
+  dps: 11197.76905
+  tps: 7983.19963
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11021.25815
-  tps: 7852.33241
+  dps: 11024.10359
+  tps: 7855.66781
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 10914.02075
-  tps: 7773.84369
+  dps: 10919.23031
+  tps: 7778.19512
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11273.81664
-  tps: 8038.65347
+  dps: 11278.14365
+  tps: 8042.35534
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11268.25378
-  tps: 8034.5592
+  dps: 11272.13533
+  tps: 8037.93321
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11172.57123
-  tps: 7964.13684
+  dps: 11179.02873
+  tps: 7969.40675
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11279.67188
-  tps: 8042.96292
+  dps: 11282.90767
+  tps: 8045.86165
   hps: 16.40824
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50179"
  value: {
-  dps: 11515.829
-  tps: 8216.77456
+  dps: 11519.94323
+  tps: 8220.31982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-LastWord-50708"
  value: {
-  dps: 11515.829
-  tps: 8216.77456
+  dps: 11519.94323
+  tps: 8220.31982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11239.04091
-  tps: 8002.10031
+  dps: 11233.16389
+  tps: 7996.81227
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11115.91456
-  tps: 7922.43753
+  dps: 11120.87428
+  tps: 7926.60508
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11272.98555
-  tps: 8038.04178
+  dps: 11276.21902
+  tps: 8040.93881
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11279.67188
-  tps: 8042.96292
+  dps: 11282.90767
+  tps: 8045.86165
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10977.45555
-  tps: 7820.36762
+  dps: 10983.93118
+  tps: 7825.63461
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10979.5923
-  tps: 7821.94027
+  dps: 10986.02324
+  tps: 7827.17436
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11515.829
-  tps: 8216.77456
+  dps: 11519.94323
+  tps: 8220.31982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 10919.53579
-  tps: 7777.90275
+  dps: 10924.7655
+  tps: 7782.26902
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 10913.60937
-  tps: 7773.54092
+  dps: 10918.81738
+  tps: 7777.8912
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9340.72994
-  tps: 6661.139
+  dps: 9316.53318
+  tps: 6643.64277
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ScourgebornePlate"
  value: {
-  dps: 8377.91198
-  tps: 5957.08113
+  dps: 8361.96602
+  tps: 5946.10754
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 11580.63535
-  tps: 8284.56951
+  dps: 11587.0856
+  tps: 8289.53163
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9187.71116
-  tps: 6531.54392
+  dps: 9192.69818
+  tps: 6535.57277
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Shadowmourne-49623"
  value: {
-  dps: 11515.829
-  tps: 8216.77456
+  dps: 11519.94323
+  tps: 8220.31982
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 10910.38691
-  tps: 7771.16919
+  dps: 10915.58275
+  tps: 7775.51051
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 10924.79465
-  tps: 7781.77328
+  dps: 10930.08159
+  tps: 7786.18166
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 10910.38691
-  tps: 7771.16919
+  dps: 10915.58275
+  tps: 7775.51051
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigilofVirulence-47673"
  value: {
-  dps: 11391.83959
-  tps: 8112.11659
+  dps: 11397.30722
+  tps: 8116.68715
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 10910.38691
-  tps: 7771.16919
+  dps: 10915.58275
+  tps: 7775.51051
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11436.04333
-  tps: 8143.37737
+  dps: 11441.5192
+  tps: 8147.95677
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 10910.38691
-  tps: 7771.16919
+  dps: 10915.58275
+  tps: 7775.51051
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11096.86898
-  tps: 7908.41999
+  dps: 11099.71704
+  tps: 7911.03335
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SparkofLife-37657"
  value: {
-  dps: 11081.23573
-  tps: 7893.36128
+  dps: 11065.21036
+  tps: 7882.31126
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11150.42322
-  tps: 7947.02059
+  dps: 11159.75539
+  tps: 7954.191
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-StormshroudArmor"
  value: {
-  dps: 8150.71637
-  tps: 5812.50645
+  dps: 8156.29403
+  tps: 5816.84199
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11279.67188
-  tps: 8042.96292
+  dps: 11282.90767
+  tps: 8045.86165
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11272.98555
-  tps: 8038.04178
+  dps: 11276.21902
+  tps: 8040.93881
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11261.28448
-  tps: 8029.4298
+  dps: 11264.51389
+  tps: 8032.32383
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 9743.75703
-  tps: 6950.60252
+  dps: 9718.37392
+  tps: 6929.77577
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8385.23221
-  tps: 5965.23827
+  dps: 8372.82983
+  tps: 5956.34852
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 9442.20386
-  tps: 6708.98286
+  dps: 9455.7411
+  tps: 6718.21594
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 11287.9509
-  tps: 8044.05685
+  dps: 11281.83662
+  tps: 8039.34274
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11235.0334
-  tps: 8010.34999
+  dps: 11221.49107
+  tps: 8003.15537
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11265.44643
-  tps: 8030.11464
+  dps: 11271.85192
+  tps: 8035.00119
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10965.37751
-  tps: 7804.27413
+  dps: 10967.61066
+  tps: 7806.067
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11244.56867
-  tps: 8017.12696
+  dps: 11247.79226
+  tps: 8020.01671
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8604.98928
-  tps: 6138.66324
+  dps: 8583.40846
+  tps: 6123.13122
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 10401.5655
-  tps: 7396.38488
+  dps: 10397.65583
+  tps: 7394.80529
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10936.41757
-  tps: 7790.32775
+  dps: 10941.74281
+  tps: 7794.76431
  }
 }
 dps_results: {
  key: "TestFrostUH-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 10921.2379
-  tps: 7779.15551
+  dps: 10926.47392
+  tps: 7783.52642
  }
 }
 dps_results: {
  key: "TestFrostUH-Average-Default"
  value: {
-  dps: 11464.60507
-  tps: 8182.11788
+  dps: 11463.43552
+  tps: 8181.36821
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 30138.29996
-  tps: 21944.86242
+  dps: 30165.50288
+  tps: 21965.09081
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11420.26813
-  tps: 8159.72125
+  dps: 11428.33686
+  tps: 8166.07502
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13452.53129
-  tps: 9285.62001
+  dps: 13450.07974
+  tps: 9286.22165
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 15565.6624
-  tps: 11306.6614
+  dps: 15584.66543
+  tps: 11321.4214
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6721.81265
-  tps: 4788.54757
+  dps: 6716.38121
+  tps: 4784.66383
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7500.22859
-  tps: 5186.98984
+  dps: 7495.20821
+  tps: 5183.23697
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31053.49838
-  tps: 22484.26773
+  dps: 31019.53503
+  tps: 22462.05453
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11734.52576
-  tps: 8256.39348
+  dps: 11771.02087
+  tps: 8286.29508
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14270.44462
-  tps: 9295.03726
+  dps: 14437.42666
+  tps: 9424.13435
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15948.14871
-  tps: 11484.38836
+  dps: 15935.20975
+  tps: 11476.7188
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 7010.56223
-  tps: 4900.16414
+  dps: 6978.60463
+  tps: 4878.86377
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Human-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8117.46924
-  tps: 5165.15626
+  dps: 8072.53234
+  tps: 5137.9248
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 29041.26465
-  tps: 21126.51505
+  dps: 29043.97616
+  tps: 21128.69123
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11515.829
-  tps: 8216.77456
+  dps: 11519.94323
+  tps: 8220.31982
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 13626.84862
-  tps: 9382.32285
+  dps: 13628.03136
+  tps: 9385.71032
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 15289.5059
-  tps: 11095.51866
+  dps: 15248.48285
+  tps: 11066.10796
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6764.64693
-  tps: 4811.33503
+  dps: 6760.01655
+  tps: 4808.02418
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7542.98059
-  tps: 5200.79076
+  dps: 7531.40886
+  tps: 5192.44123
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31073.73354
-  tps: 22490.42207
+  dps: 31277.20636
+  tps: 22639.936
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11704.45187
-  tps: 8223.94478
+  dps: 11739.89898
+  tps: 8252.1785
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14315.5056
-  tps: 9303.98097
+  dps: 14508.00621
+  tps: 9450.1939
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16026.85371
-  tps: 11535.42284
+  dps: 16110.57527
+  tps: 11597.33613
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-LongSingleTarget"
  value: {
-  dps: 7045.82632
-  tps: 4919.75063
+  dps: 7034.3297
+  tps: 4912.91878
  }
 }
 dps_results: {
  key: "TestFrostUH-Settings-Orc-p3_frost-Basic-frost_uh_pesti-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8145.59368
-  tps: 5170.86478
+  dps: 8129.98022
+  tps: 5165.17253
  }
 }
 dps_results: {
  key: "TestFrostUH-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 10750.72509
-  tps: 7684.75292
+  dps: 10541.53231
+  tps: 7527.04969
  }
 }

--- a/sim/deathknight/dps/TestUnholy.results
+++ b/sim/deathknight/dps/TestUnholy.results
@@ -46,1376 +46,1376 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11427.38189
-  tps: 7557.30128
-  hps: 423.60582
+  dps: 11414.26752
+  tps: 7547.03506
+  hps: 425.67936
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11427.38189
-  tps: 7557.30128
-  hps: 437.3744
+  dps: 11414.26752
+  tps: 7547.03506
+  hps: 439.44364
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 325.06505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 11637.2619
-  tps: 7726.79708
-  hps: 318.90115
+  dps: 11642.12954
+  tps: 7732.7326
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 11427.40535
-  tps: 7557.2988
-  hps: 411.96954
+  dps: 11414.31665
+  tps: 7547.05657
+  hps: 414.03487
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 11427.40535
-  tps: 7557.2988
-  hps: 411.96954
+  dps: 11414.31665
+  tps: 7547.05657
+  hps: 414.03487
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 11963.32345
-  tps: 7816.11845
+  dps: 11963.63848
+  tps: 7812.90115
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 11334.36753
-  tps: 7296.74245
-  hps: 305.28353
+  dps: 11305.70494
+  tps: 7289.36219
+  hps: 304.07048
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 8862.9486
-  tps: 5697.01178
-  hps: 261.31791
+  dps: 8878.94874
+  tps: 5719.74852
+  hps: 258.22336
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 8788.76654
-  tps: 5706.05214
-  hps: 242.97233
+  dps: 8726.54924
+  tps: 5648.14007
+  hps: 245.93943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8542.22504
-  tps: 5516.08441
-  hps: 243.82849
+  dps: 8524.62606
+  tps: 5479.29989
+  hps: 245.13763
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7636.2007
+  dps: 11937.72847
+  tps: 7632.81876
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 12085.30627
-  tps: 7929.80145
+  dps: 12083.81268
+  tps: 7924.89222
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 12085.30627
-  tps: 7929.80145
+  dps: 12083.81268
+  tps: 7924.89222
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 12095.77848
-  tps: 7941.01147
+  dps: 12096.35877
+  tps: 7938.00715
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 414.645
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 416.96102
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11589.17529
-  tps: 7700.81903
-  hps: 318.90115
+  dps: 11577.79044
+  tps: 7692.49233
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 11611.95409
-  tps: 7721.13227
-  hps: 318.90115
+  dps: 11617.92693
+  tps: 7728.17796
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11787.26491
-  tps: 7747.64192
-  hps: 318.90115
+  dps: 11773.00063
+  tps: 7736.17274
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 9902.95994
-  tps: 6420.80504
-  hps: 292.59093
+  dps: 9885.43163
+  tps: 6402.59186
+  hps: 292.20184
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkrunedPlate"
  value: {
-  dps: 8817.8459
-  tps: 5666.39294
-  hps: 309.44931
+  dps: 8840.95601
+  tps: 5678.94407
+  hps: 306.17038
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeadlyGladiator'sSigilofStrife-42620"
  value: {
-  dps: 11993.68647
-  tps: 7966.84609
-  hps: 350.91764
+  dps: 12019.64541
+  tps: 7988.39611
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 11544.40156
-  tps: 7659.839
-  hps: 318.90115
+  dps: 11534.50075
+  tps: 7655.12605
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11907.21422
-  tps: 7967.09032
+  dps: 11901.20713
+  tps: 7961.16433
   hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11913.48115
-  tps: 8006.41255
-  hps: 322.27131
+  dps: 11974.35285
+  tps: 8056.00702
+  hps: 325.64146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 11967.38421
-  tps: 7821.7232
+  dps: 11970.0077
+  tps: 7818.4194
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 11798.98234
-  tps: 7724.62368
-  hps: 319.74369
+  dps: 11844.44105
+  tps: 7773.03322
+  hps: 318.90115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 11803.88112
-  tps: 7738.28514
-  hps: 318.90115
+  dps: 11805.54971
+  tps: 7736.22133
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 325.06505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 11963.32345
-  tps: 7816.11845
+  dps: 11963.63848
+  tps: 7812.90115
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 11959.32575
-  tps: 7812.68241
+  dps: 11958.24871
+  tps: 7807.95674
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 11729.8975
-  tps: 7643.75691
-  hps: 320.16496
+  dps: 11728.30743
+  tps: 7639.95609
+  hps: 319.74369
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 334.35539
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 336.56382
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 11638.27462
-  tps: 7747.74398
-  hps: 318.90115
+  dps: 11637.58915
+  tps: 7748.11076
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11563.92239
-  tps: 7677.2556
-  hps: 318.90115
+  dps: 11555.73838
+  tps: 7670.53783
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11536.58726
-  tps: 7652.15601
-  hps: 318.90115
+  dps: 11527.22796
+  tps: 7645.34384
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuriousGladiator'sSigilofStrife-42621"
  value: {
-  dps: 12012.31028
-  tps: 7981.57126
-  hps: 350.91764
+  dps: 12038.47646
+  tps: 8003.34717
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 11698.89649
-  tps: 7780.62375
-  hps: 318.90115
+  dps: 11685.35911
+  tps: 7769.91286
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11427.36959
-  tps: 7557.23875
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11427.36959
-  tps: 7557.23875
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 11562.0796
-  tps: 7675.942
-  hps: 318.90115
+  dps: 11568.66221
+  tps: 7685.62282
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HatefulGladiator'sSigilofStrife-42619"
  value: {
-  dps: 11955.15893
-  tps: 7935.01942
-  hps: 350.91764
+  dps: 11979.04945
+  tps: 7955.70519
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 11963.32345
-  tps: 7816.11845
+  dps: 11963.63848
+  tps: 7812.90115
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 11959.32575
-  tps: 7812.68241
+  dps: 11958.24871
+  tps: 7807.95674
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 11623.84747
-  tps: 7720.83207
-  hps: 318.90115
+  dps: 11610.92811
+  tps: 7710.69766
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11974.33314
-  tps: 7821.95634
-  hps: 337.06992
+  dps: 11975.06736
+  tps: 7818.49556
+  hps: 336.96493
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 12085.30627
-  tps: 7929.80145
+  dps: 12083.81268
+  tps: 7924.89222
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 12085.30627
-  tps: 7929.80145
+  dps: 12083.81268
+  tps: 7924.89222
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 11427.36959
-  tps: 7557.23875
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11783.89445
-  tps: 7752.94483
-  hps: 318.05861
+  dps: 11796.02982
+  tps: 7773.75701
+  hps: 318.47988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11570.6515
-  tps: 7695.30299
-  hps: 318.90115
+  dps: 11547.14179
+  tps: 7675.54146
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 11427.36959
-  tps: 7557.23875
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 11967.22266
-  tps: 7816.25829
+  dps: 11967.95519
+  tps: 7812.79938
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11974.33314
-  tps: 7821.95634
+  dps: 11975.06736
+  tps: 7818.49556
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 11427.36959
-  tps: 7557.23875
-  hps: 318.90115
+  dps: 11414.19341
+  tps: 7546.93036
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 324.22527
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 325.06505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 11497.14861
-  tps: 7617.4335
-  hps: 318.90115
+  dps: 11499.40312
+  tps: 7615.99937
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 11507.52805
-  tps: 7626.1279
-  hps: 318.90115
+  dps: 11509.94063
+  tps: 7624.80028
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 12085.30627
-  tps: 7929.80145
+  dps: 12083.81268
+  tps: 7924.89222
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessGladiator'sSigilofStrife-42622"
  value: {
-  dps: 12034.03806
-  tps: 7998.75062
-  hps: 350.91764
+  dps: 12060.44602
+  tps: 8020.79008
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SavageGladiator'sSigilofStrife-42618"
  value: {
-  dps: 11948.97966
-  tps: 7930.28882
-  hps: 350.91764
+  dps: 11972.98862
+  tps: 7950.94697
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 9511.68442
-  tps: 6138.4147
-  hps: 276.15832
+  dps: 9494.29344
+  tps: 6118.1696
+  hps: 274.6991
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScourgebornePlate"
  value: {
-  dps: 8738.35278
-  tps: 5597.40027
-  hps: 286.09046
+  dps: 8780.66433
+  tps: 5624.13964
+  hps: 285.71002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 11182.43968
-  tps: 7497.93479
-  hps: 336.35856
+  dps: 11189.481
+  tps: 7510.79576
+  hps: 334.57416
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 9865.78888
-  tps: 6483.14256
+  dps: 9867.25274
+  tps: 6489.89862
   hps: 358.58418
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 12085.30627
-  tps: 7929.80145
+  dps: 12083.81268
+  tps: 7924.89222
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDeflection-45144"
  value: {
-  dps: 11900.56742
-  tps: 7893.22026
-  hps: 350.91764
+  dps: 11925.49016
+  tps: 7913.6408
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofHauntedDreams-40715"
  value: {
-  dps: 11922.01055
-  tps: 7914.45329
-  hps: 350.91764
+  dps: 11941.28731
+  tps: 7928.48889
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofInsolence-47672"
  value: {
-  dps: 11900.56742
-  tps: 7893.22026
-  hps: 350.91764
+  dps: 11925.49016
+  tps: 7913.6408
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheBoneGryphon-50462"
  value: {
-  dps: 11900.56742
-  tps: 7893.22026
-  hps: 350.91764
+  dps: 11925.49016
+  tps: 7913.6408
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheHangedMan-50459"
  value: {
-  dps: 11900.56742
-  tps: 7893.22026
-  hps: 350.91764
+  dps: 11925.49016
+  tps: 7913.6408
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheUnfalteringKnight-40714"
  value: {
-  dps: 11900.56742
-  tps: 7893.22026
-  hps: 350.91764
+  dps: 11925.49016
+  tps: 7913.6408
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 11427.36959
-  tps: 7557.23875
-  hps: 350.645
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 352.96102
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11571.71697
-  tps: 7685.77118
-  hps: 318.90115
+  dps: 11561.72048
+  tps: 7677.05299
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 11594.61591
-  tps: 7622.08448
+  dps: 11564.52754
+  tps: 7603.21264
   hps: 315.95226
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11673.1171
-  tps: 7701.83533
-  hps: 316.7948
+  dps: 11663.49836
+  tps: 7699.66172
+  hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StormshroudArmor"
  value: {
-  dps: 8434.15544
-  tps: 5485.85536
-  hps: 228.8254
+  dps: 8386.60885
+  tps: 5442.17756
+  hps: 229.13337
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11974.33314
-  tps: 7821.95634
+  dps: 11975.06736
+  tps: 7818.49556
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 11967.22266
-  tps: 7816.25829
+  dps: 11967.95519
+  tps: 7812.79938
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 11954.77933
-  tps: 7806.28668
+  dps: 11955.50889
+  tps: 7802.83105
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 10148.07054
-  tps: 6624.96049
-  hps: 291.31811
+  dps: 10119.09526
+  tps: 6600.92998
+  hps: 291.70499
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Thassarian'sPlate"
  value: {
-  dps: 8821.22604
-  tps: 5627.39565
-  hps: 297.86252
+  dps: 8839.95403
+  tps: 5649.15697
+  hps: 298.66865
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 10590.75861
-  tps: 6838.42363
-  hps: 305.19928
+  dps: 10590.39323
+  tps: 6849.74277
+  hps: 303.97686
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 12106.23218
-  tps: 7881.25419
-  hps: 318.90115
+  dps: 12093.88698
+  tps: 7894.15863
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11721.98757
-  tps: 7784.76441
-  hps: 319.32242
+  dps: 11716.5971
+  tps: 7793.6541
+  hps: 319.74369
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11714.96816
-  tps: 7801.85837
-  hps: 319.32242
+  dps: 11718.30012
+  tps: 7799.56671
+  hps: 323.11384
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 11553.86555
-  tps: 7561.08618
+  dps: 11587.86414
+  tps: 7590.43591
   hps: 318.47988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 11937.00313
-  tps: 7792.04153
+  dps: 11937.72847
+  tps: 7788.59057
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8752.28657
-  tps: 5681.89259
-  hps: 247.24819
+  dps: 8808.39201
+  tps: 5715.13913
+  hps: 249.2693
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 11385.16999
-  tps: 7403.22618
-  hps: 322.38136
+  dps: 11370.50221
+  tps: 7384.82096
+  hps: 322.99114
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11427.38925
-  tps: 7557.26863
-  hps: 318.90115
+  dps: 11414.21307
+  tps: 7546.96024
+  hps: 321.0075
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathfulGladiator'sSigilofStrife-51417"
  value: {
-  dps: 12058.86981
-  tps: 8018.38417
-  hps: 350.91764
+  dps: 12085.55409
+  tps: 8040.72483
+  hps: 350.0751
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 12078.91572
-  tps: 7959.90618
-  hps: 319.04123
+  dps: 12076.65937
+  tps: 7957.12416
+  hps: 319.15199
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58280.47517
-  tps: 61021.43118
+  dps: 58296.9622
+  tps: 60962.86028
   hps: 319.60409
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 11888.74472
-  tps: 7918.88737
-  hps: 317.49866
+  dps: 11895.77644
+  tps: 7918.73067
+  hps: 318.76192
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16860.17255
-  tps: 8819.13821
+  dps: 16868.20504
+  tps: 8808.87504
   hps: 216.85917
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35223.33975
-  tps: 37943.43775
-  hps: 205.0688
+  dps: 35212.7525
+  tps: 37794.05129
+  hps: 209.2256
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6075.76095
-  tps: 4427.09091
-  hps: 207.00864
+  dps: 6080.051
+  tps: 4429.86433
+  hps: 208.67136
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7569.8533
-  tps: 4476.78422
+  dps: 7575.90788
+  tps: 4476.13752
   hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14179.39059
-  tps: 9318.21524
+  dps: 14197.9841
+  tps: 9329.47559
   hps: 42.10858
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10186.10759
-  tps: 5980.5064
+  dps: 10194.12341
+  tps: 5985.56577
   hps: 42.10858
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15192.62444
-  tps: 7225.09938
+  dps: 15179.31445
+  tps: 7213.71158
   hps: 210.54288
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6744.16236
-  tps: 4604.49335
+  dps: 6741.89766
+  tps: 4602.89579
   hps: 27.712
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5050.35357
-  tps: 3186.95047
+  dps: 5049.93622
+  tps: 3187.41607
   hps: 27.712
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6549.7935
-  tps: 3456.83938
+  dps: 6573.48109
+  tps: 3475.97891
   hps: 138.56
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 58942.3402
-  tps: 61017.47906
+  dps: 58871.57778
+  tps: 60989.81613
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11164.40598
-  tps: 7462.6297
+  dps: 11179.88295
+  tps: 7471.7883
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16045.39672
-  tps: 8635.02391
+  dps: 16089.34451
+  tps: 8670.08597
   hps: 336.86861
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 35132.80971
-  tps: 37558.75667
+  dps: 34683.47273
+  tps: 37073.98028
   hps: 155.46432
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5698.87988
-  tps: 4172.71855
+  dps: 5699.46006
+  tps: 4174.42333
   hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7129.14968
-  tps: 4428.01985
+  dps: 7137.63313
+  tps: 4441.92854
   hps: 221.696
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 35990.88456
-  tps: 43008.49804
+  dps: 36060.60293
+  tps: 43125.72113
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11339.44504
-  tps: 7606.11393
+  dps: 11338.74558
+  tps: 7619.39594
   hps: 235.80803
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16142.49486
-  tps: 8758.98024
+  dps: 16136.30807
+  tps: 8765.77575
   hps: 336.86861
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18635.57219
-  tps: 22848.18912
+  dps: 18624.41707
+  tps: 22828.96296
   hps: 155.74144
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5805.93058
-  tps: 4263.43171
+  dps: 5822.89427
+  tps: 4277.01692
   hps: 155.1872
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Human-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7191.56328
-  tps: 4488.63377
+  dps: 7193.26094
+  tps: 4488.09576
   hps: 221.696
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--FullBuffs-LongMultiTarget"
  value: {
-  dps: 58726.22467
-  tps: 61185.14463
-  hps: 317.63734
+  dps: 58601.05031
+  tps: 61034.18079
+  hps: 318.05861
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--FullBuffs-LongSingleTarget"
  value: {
-  dps: 12085.30627
-  tps: 7929.80145
+  dps: 12083.81268
+  tps: 7924.89222
   hps: 320.58623
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 17330.35872
-  tps: 8901.81176
+  dps: 17312.96638
+  tps: 8894.46753
   hps: 216.95389
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--NoBuffs-LongMultiTarget"
  value: {
-  dps: 35557.93766
-  tps: 38289.66635
-  hps: 204.90401
+  dps: 35513.43113
+  tps: 38139.98039
+  hps: 207.12218
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--NoBuffs-LongSingleTarget"
  value: {
-  dps: 6174.00076
-  tps: 4448.72091
-  hps: 209.61763
+  dps: 6164.3613
+  tps: 4437.04944
+  hps: 208.78582
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7772.61665
-  tps: 4506.71482
+  dps: 7772.27338
+  tps: 4497.82128
   hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14381.33767
-  tps: 9390.01453
+  dps: 14275.55112
+  tps: 9275.62941
   hps: 42.12697
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10357.92928
-  tps: 6019.32421
+  dps: 10346.91539
+  tps: 5989.61257
   hps: 42.12697
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15543.1462
-  tps: 7259.16262
+  dps: 15451.74278
+  tps: 7165.07213
   hps: 210.63484
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 6775.67534
-  tps: 4586.8259
+  dps: 6761.4395
+  tps: 4575.413
   hps: 27.7272
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5089.06106
-  tps: 3172.48417
+  dps: 5085.97636
+  tps: 3172.95627
   hps: 27.7272
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_2h_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6695.09468
-  tps: 3490.0449
+  dps: 6701.62049
+  tps: 3491.63258
   hps: 138.636
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 59298.99112
-  tps: 61223.75387
+  dps: 59321.04606
+  tps: 61361.65332
   hps: 236.33229
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11283.17499
-  tps: 7436.80951
-  hps: 235.91102
+  dps: 11318.78456
+  tps: 7472.9393
+  hps: 236.33229
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16371.85419
-  tps: 8626.20755
+  dps: 16412.5451
+  tps: 8686.56163
   hps: 337.01574
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 34818.24048
-  tps: 37153.54114
+  dps: 35117.90018
+  tps: 37478.75367
   hps: 155.82686
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5734.1026
-  tps: 4163.33424
+  dps: 5750.84606
+  tps: 4175.86894
   hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-uh_dnd_aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7257.5883
-  tps: 4454.30988
+  dps: 7280.02322
+  tps: 4471.44132
   hps: 221.8176
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongMultiTarget"
  value: {
-  dps: 36251.57703
-  tps: 43192.08813
+  dps: 36238.79517
+  tps: 43195.85148
   hps: 236.33229
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11472.03296
-  tps: 7613.57463
+  dps: 11434.83628
+  tps: 7578.90963
   hps: 236.33229
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 16449.17207
-  tps: 8758.38718
-  hps: 337.01574
+  dps: 16487.2343
+  tps: 8798.61633
+  hps: 339.12209
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18695.48835
-  tps: 22875.53811
+  dps: 18696.93865
+  tps: 22871.51167
   hps: 155.82686
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5859.32157
-  tps: 4268.71422
+  dps: 5876.43297
+  tps: 4281.49641
   hps: 155.27232
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3_uh_dw-Basic-unholy_dw_ss-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 7325.51313
-  tps: 4518.32522
+  dps: 7351.97253
+  tps: 4548.398
   hps: 221.8176
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 11611.00152
-  tps: 7669.45859
-  hps: 310.05448
+  dps: 11645.71716
+  tps: 7685.00028
+  hps: 315.95226
  }
 }

--- a/sim/deathknight/ghoul_pet.go
+++ b/sim/deathknight/ghoul_pet.go
@@ -1,10 +1,11 @@
 package deathknight
 
 import (
+	"time"
+
 	"github.com/wowsims/wotlk/sim/core"
 	"github.com/wowsims/wotlk/sim/core/proto"
 	"github.com/wowsims/wotlk/sim/core/stats"
-	"time"
 )
 
 type GhoulPet struct {
@@ -151,7 +152,7 @@ func (ghoulPet *GhoulPet) Reset(_ *core.Simulation) {
 	}
 }
 
-func (ghoulPet *GhoulPet) OnGCDReady(sim *core.Simulation) {
+func (ghoulPet *GhoulPet) ExecuteCustomRotation(sim *core.Simulation) {
 	if ghoulPet.uptimePercent < 1.0 { // Apply uptime for permanent pet ghoul
 		if sim.GetRemainingDurationPercent() < 1.0-ghoulPet.uptimePercent { // once fight is % completed, disable pet.
 			ghoulPet.Pet.Disable(sim)
@@ -160,7 +161,6 @@ func (ghoulPet *GhoulPet) OnGCDReady(sim *core.Simulation) {
 	}
 
 	if ghoulPet.CurrentFocus() < ghoulPet.Claw.DefaultCast.Cost {
-		ghoulPet.DoNothing()
 		return
 	}
 

--- a/sim/deathknight/summon_gargoyle.go
+++ b/sim/deathknight/summon_gargoyle.go
@@ -138,7 +138,7 @@ func (garg *GargoylePet) Initialize() {
 func (garg *GargoylePet) Reset(_ *core.Simulation) {
 }
 
-func (garg *GargoylePet) OnGCDReady(_ *core.Simulation) {
+func (garg *GargoylePet) ExecuteCustomRotation(_ *core.Simulation) {
 }
 
 func (garg *GargoylePet) registerGargoyleStrikeSpell() {

--- a/sim/deathknight/tank/TestBloodTank.results
+++ b/sim/deathknight/tank/TestBloodTank.results
@@ -46,965 +46,965 @@ character_stats_results: {
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 2194.33941
-  tps: 6697.38448
+  dps: 2182.4523
+  tps: 6658.62858
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 2112.41683
-  tps: 6527.80845
-  hps: 82.49012
+  dps: 2092.85584
+  tps: 6403.74046
+  hps: 82.435
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 2112.41683
-  tps: 6527.80845
-  hps: 82.49012
+  dps: 2092.85584
+  tps: 6403.74046
+  hps: 82.435
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 2114.30558
-  tps: 6532.46699
+  dps: 2094.24827
+  tps: 6409.92305
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 2086.40099
-  tps: 6384.43233
+  dps: 2059.15388
+  tps: 6316.06769
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 1958.60616
-  tps: 6002.1816
+  dps: 1954.12274
+  tps: 6019.96369
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 1912.28698
-  tps: 5822.35801
+  dps: 1900.57667
+  tps: 5775.28782
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 1797.20938
-  tps: 5433.27165
+  dps: 1794.45241
+  tps: 5457.40424
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6386.19631
+  dps: 2089.58368
+  tps: 6264.92673
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 2577.47138
-  tps: 7598.66498
+  dps: 2573.99526
+  tps: 7603.53058
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 2616.56261
-  tps: 7656.30924
+  dps: 2614.31574
+  tps: 7641.05069
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 2130.66524
-  tps: 6587.64073
+  dps: 2109.88394
+  tps: 6462.80689
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
   hps: 64
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 2143.15785
-  tps: 6628.47604
+  dps: 2120.3374
+  tps: 6502.36427
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 2187.2656
-  tps: 6647.36737
+  dps: 2168.44648
+  tps: 6604.08781
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 2181.40736
-  tps: 6740.61927
+  dps: 2162.61958
+  tps: 6614.66232
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedBattlegear"
  value: {
-  dps: 2400.30889
-  tps: 7268.86155
+  dps: 2403.10357
+  tps: 7401.76305
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DarkrunedPlate"
  value: {
-  dps: 2109.23582
-  tps: 6507.60126
+  dps: 2099.02262
+  tps: 6430.10576
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Death'sChoice-47464"
  value: {
-  dps: 2301.59673
-  tps: 7143.09576
+  dps: 2280.72705
+  tps: 7012.55514
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 2127.94429
-  tps: 6577.3218
+  dps: 2107.82173
+  tps: 6456.57973
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 2232.37668
-  tps: 6804.98168
+  dps: 2228.69738
+  tps: 6815.03978
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 2248.15636
-  tps: 6881.27486
+  dps: 2250.37959
+  tps: 6838.055
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Defender'sCode-40257"
  value: {
-  dps: 2118.46229
-  tps: 6548.98361
+  dps: 2098.84136
+  tps: 6424.61479
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 2115.88902
-  tps: 6535.75026
+  dps: 2095.59119
+  tps: 6412.7076
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 2165.69335
-  tps: 6571.60861
+  dps: 2164.83341
+  tps: 6576.29132
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 2170.49482
-  tps: 6542.49772
+  dps: 2167.99481
+  tps: 6581.16366
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 2114.30558
-  tps: 6532.46699
+  dps: 2094.24827
+  tps: 6409.92305
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 2113.07411
-  tps: 6529.91353
+  dps: 2093.37733
+  tps: 6405.71907
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 2155.12033
-  tps: 6591.91133
+  dps: 2145.43484
+  tps: 6530.15115
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 2175.01138
-  tps: 6647.95168
+  dps: 2164.18137
+  tps: 6601.00834
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 2138.55838
-  tps: 6606.80207
+  dps: 2115.62376
+  tps: 6485.29199
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForgeEmber-37660"
  value: {
-  dps: 2134.58782
-  tps: 6590.90621
+  dps: 2111.17092
+  tps: 6473.48509
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 2187.92218
-  tps: 6798.94789
+  dps: 2167.46278
+  tps: 6669.28015
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-FuturesightRune-38763"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 2164.09139
-  tps: 6626.19025
+  dps: 2152.49846
+  tps: 6634.4122
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 2114.30558
-  tps: 6532.46699
+  dps: 2094.24827
+  tps: 6409.92305
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 2113.07411
-  tps: 6529.91353
+  dps: 2093.37733
+  tps: 6405.71907
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-IncisorFragment-37723"
  value: {
-  dps: 2169.25735
-  tps: 6698.54552
+  dps: 2149.26901
+  tps: 6572.0285
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 2119.81977
-  tps: 6553.69
+  dps: 2100.18377
+  tps: 6429.23065
   hps: 15.08033
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50179"
  value: {
-  dps: 2362.81459
-  tps: 7125.9177
+  dps: 2363.74637
+  tps: 7087.42834
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-LastWord-50708"
  value: {
-  dps: 2385.3674
-  tps: 7184.60741
+  dps: 2386.40737
+  tps: 7146.58324
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 2168.79862
-  tps: 6652.52501
+  dps: 2162.56793
+  tps: 6591.00462
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 2156.49448
-  tps: 6668.6766
+  dps: 2139.26121
+  tps: 6539.71751
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 2116.33548
-  tps: 6541.60997
+  dps: 2096.73817
+  tps: 6417.38299
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 2117.77803
-  tps: 6546.61131
+  dps: 2098.1647
+  tps: 6422.28812
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 2119.81977
-  tps: 6553.69
+  dps: 2100.18377
+  tps: 6429.23065
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 2128.61423
-  tps: 6584.18046
+  dps: 2108.88059
+  tps: 6459.13459
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 2130.6985
-  tps: 6591.40663
+  dps: 2110.94172
+  tps: 6466.22175
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 2125.79192
-  tps: 6526.43905
+  dps: 2122.47339
+  tps: 6473.48537
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 2128.63514
-  tps: 6532.33446
+  dps: 2125.30681
+  tps: 6479.36046
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 2128.66694
-  tps: 6578.50078
+  dps: 2108.309
+  tps: 6452.07017
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgeborneBattlegear"
  value: {
-  dps: 2284.10733
-  tps: 6988.61219
+  dps: 2283.53635
+  tps: 7034.23295
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ScourgebornePlate"
  value: {
-  dps: 2094.00628
-  tps: 6421.70877
+  dps: 2069.031
+  tps: 6357.89703
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sBattlegear"
  value: {
-  dps: 2819.55049
-  tps: 8769.16553
+  dps: 2791.61313
+  tps: 8676.60677
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Scourgelord'sPlate"
  value: {
-  dps: 2369.21163
-  tps: 7920.62357
+  dps: 2366.31976
+  tps: 7984.82592
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 2117.54089
-  tps: 6545.77247
+  dps: 2097.93271
+  tps: 6421.45185
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Shadowmourne-49623"
  value: {
-  dps: 2850.88574
-  tps: 8394.63681
+  dps: 2843.14575
+  tps: 8416.1353
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SoulPreserver-37111"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SouloftheDead-40382"
  value: {
-  dps: 2139.78481
-  tps: 6611.64397
+  dps: 2117.05423
+  tps: 6490.29835
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SparkofLife-37657"
  value: {
-  dps: 2138.23014
-  tps: 6473.98925
+  dps: 2130.95176
+  tps: 6504.27741
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 2179.28371
-  tps: 6608.97476
+  dps: 2173.05109
+  tps: 6656.36804
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-StormshroudArmor"
  value: {
-  dps: 1774.17815
-  tps: 5402.52686
+  dps: 1783.4818
+  tps: 5460.04228
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 2119.81977
-  tps: 6553.69
+  dps: 2100.18377
+  tps: 6429.23065
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 2117.77803
-  tps: 6546.61131
+  dps: 2098.1647
+  tps: 6422.28812
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 2114.205
-  tps: 6534.22359
+  dps: 2094.63134
+  tps: 6410.1387
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sBattlegear"
  value: {
-  dps: 2454.59064
-  tps: 7540.40482
+  dps: 2454.04426
+  tps: 7504.81505
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Thassarian'sPlate"
  value: {
-  dps: 2123.15655
-  tps: 6540.56758
+  dps: 2112.44911
+  tps: 6541.55393
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 2053.59603
-  tps: 6353.77311
+  dps: 2050.14145
+  tps: 6370.48516
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 2121.22381
-  tps: 6526.40659
+  dps: 2115.18183
+  tps: 6549.55214
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 2193.0009
-  tps: 6652.95022
+  dps: 2183.08896
+  tps: 6634.27764
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 2188.29779
-  tps: 6672.43844
+  dps: 2188.6023
+  tps: 6614.03808
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 2133.42002
-  tps: 6486.13984
+  dps: 2129.68284
+  tps: 6527.63635
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 2109.10067
-  tps: 6516.52685
+  dps: 2089.58368
+  tps: 6392.78238
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 1899.49584
-  tps: 5796.53094
+  dps: 1901.63783
+  tps: 5793.62191
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 1825.712
-  tps: 5811.22242
+  dps: 1818.52878
+  tps: 5767.87681
  }
 }
 dps_results: {
  key: "TestBloodTank-AllItems-WingedTalisman-37844"
  value: {
-  dps: 2112.43634
-  tps: 6528.09163
+  dps: 2092.88231
+  tps: 6404.12469
  }
 }
 dps_results: {
  key: "TestBloodTank-Average-Default"
  value: {
-  dps: 2481.58973
-  tps: 8346.17239
-  dtps: 293.23961
+  dps: 2479.18054
+  tps: 8343.44881
+  dtps: 293.22894
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2030.03462
-  tps: 4459.13487
+  dps: 2020.19448
+  tps: 4432.83998
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2030.03462
-  tps: 4459.13487
+  dps: 2020.19448
+  tps: 4432.83998
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3008.30647
-  tps: 4915.71297
+  dps: 2980.30818
+  tps: 4858.22115
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1222.61533
-  tps: 2644.05091
+  dps: 1225.01498
+  tps: 2664.74001
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1222.61533
-  tps: 2644.05091
+  dps: 1225.01498
+  tps: 2664.74001
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1796.2285
-  tps: 2715.34894
+  dps: 1801.44368
+  tps: 2740.0114
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7762.99393
-  tps: 18193.6846
+  dps: 7745.52076
+  tps: 18102.02968
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2161.759
-  tps: 6593.5782
+  dps: 2163.90452
+  tps: 6596.21844
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3129.86007
-  tps: 7107.78937
+  dps: 3098.24113
+  tps: 6985.78794
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4205.46741
-  tps: 9932.95112
+  dps: 4185.18094
+  tps: 9901.97598
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1299.64111
-  tps: 3875.31972
+  dps: 1294.6015
+  tps: 3901.11189
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Human-p1_blood-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1863.46961
-  tps: 4010.5147
+  dps: 1835.78984
+  tps: 3915.6578
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 2049.29904
-  tps: 4494.87167
+  dps: 2039.30235
+  tps: 4467.86326
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2049.29904
-  tps: 4494.87167
+  dps: 2039.30235
+  tps: 4467.86326
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3044.29456
-  tps: 4970.29957
+  dps: 3016.69651
+  tps: 4913.21778
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1236.73155
-  tps: 2670.48989
+  dps: 1239.15154
+  tps: 2691.3522
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1236.73155
-  tps: 2670.48989
+  dps: 1239.15154
+  tps: 2691.3522
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_aggro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1824.07218
-  tps: 2762.57632
+  dps: 1829.04042
+  tps: 2786.93331
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-LongMultiTarget"
  value: {
-  dps: 7849.6422
-  tps: 18376.37516
+  dps: 7828.95723
+  tps: 18278.01377
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-LongSingleTarget"
  value: {
-  dps: 2181.78571
-  tps: 6639.52598
+  dps: 2183.20899
+  tps: 6638.8805
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 3170.19748
-  tps: 7173.87669
+  dps: 3136.04679
+  tps: 7047.36066
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4261.16655
-  tps: 10052.21822
+  dps: 4239.70081
+  tps: 10019.36786
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1313.76492
-  tps: 3907.90198
+  dps: 1308.80595
+  tps: 3935.42577
  }
 }
 dps_results: {
  key: "TestBloodTank-Settings-Orc-p1_blood-Basic-blood_icy_touch-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 1890.20107
-  tps: 4057.06063
+  dps: 1862.24966
+  tps: 3962.08384
  }
 }
 dps_results: {
  key: "TestBloodTank-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2518.72417
-  tps: 8346.67457
-  dtps: 270.18813
+  dps: 2505.44739
+  tps: 8266.5301
+  dtps: 270.5389
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -46,51 +46,51 @@ character_stats_results: {
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 8002.87333
-  tps: 7789.29966
+  dps: 7980.08802
+  tps: 7748.47685
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 8041.81314
-  tps: 7827.19729
+  dps: 8018.91322
+  tps: 7786.25987
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 7785.19028
-  tps: 7578.19818
+  dps: 7763.27301
+  tps: 7538.24341
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7686.25843
-  tps: 7481.16435
+  dps: 7664.36359
+  tps: 7441.23202
   hps: 93.97352
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7686.25843
-  tps: 7481.16435
+  dps: 7664.36359
+  tps: 7441.23202
   hps: 93.97352
  }
 }
@@ -98,869 +98,869 @@ dps_results: {
  key: "TestBalance-AllItems-BeamingEarthsiegeDiamond"
  value: {
   dps: 7802.78821
-  tps: 7596.85428
+  tps: 7580.65672
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5720.41234
-  tps: 5496.95081
+  dps: 4491.62438
+  tps: 4231.87022
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7838.70155
-  tps: 7480.88319
+  dps: 7811.73815
+  tps: 7435.96223
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7835.41662
-  tps: 7630.31525
+  dps: 7832.50106
+  tps: 7611.58252
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7789.39857
-  tps: 7584.98835
+  dps: 7775.39042
+  tps: 7553.38787
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DarkmoonCard:Greatness-44255"
  value: {
   dps: 7845.34242
-  tps: 7645.79254
+  tps: 7635.66641
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7744.02703
-  tps: 7538.16473
+  dps: 7713.87473
+  tps: 7490.78828
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7819.2719
-  tps: 7612.22024
+  dps: 7801.77177
+  tps: 7577.09423
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 8298.89922
-  tps: 8089.75501
+  dps: 8204.95056
+  tps: 7974.76343
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 8274.57791
-  tps: 8066.62793
+  dps: 8218.59053
+  tps: 7990.63951
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 4078.16715
-  tps: 3852.84983
+  dps: 3251.98879
+  tps: 2999.62192
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-DreamwalkerGarb"
  value: {
-  dps: 6898.47341
-  tps: 6697.27388
+  dps: 6687.01048
+  tps: 6461.91247
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7850.017
-  tps: 7642.59563
+  dps: 7844.41089
+  tps: 7620.12968
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7802.78821
-  tps: 7596.48642
+  dps: 7780.7358
+  tps: 7556.39651
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7801.02483
-  tps: 7594.68532
+  dps: 7776.65072
+  tps: 7552.23597
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7793.73744
-  tps: 7589.92458
+  dps: 7705.24556
+  tps: 7480.01716
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7812.97576
-  tps: 7608.90131
+  dps: 7803.43544
+  tps: 7582.59046
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 8052.13852
-  tps: 7845.00593
+  dps: 8016.05896
+  tps: 7792.54541
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Figurine-SapphireOwl-42413"
  value: {
   dps: 7729.22992
-  tps: 7524.41052
+  tps: 7510.99467
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7882.51388
-  tps: 7672.16151
+  dps: 7860.08285
+  tps: 7631.69298
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7964.72773
-  tps: 7757.58952
+  dps: 7927.06888
+  tps: 7703.31637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7838.70155
-  tps: 7631.02532
+  dps: 7811.73815
+  tps: 7585.56509
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7830.1132
-  tps: 7622.67128
+  dps: 7803.18008
+  tps: 7577.24134
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7821.08385
-  tps: 7611.43489
+  dps: 7798.90811
+  tps: 7571.22165
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 4440.09794
-  tps: 4219.73879
+  dps: 3485.50766
+  tps: 3235.71052
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 7301.85611
-  tps: 7077.15679
+  dps: 7261.53171
+  tps: 7017.7749
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 8022.34324
-  tps: 7808.24847
+  dps: 7999.50062
+  tps: 7767.36836
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 8066.59303
-  tps: 7851.31397
+  dps: 8043.62017
+  tps: 7810.30361
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7799.84787
-  tps: 7594.69684
+  dps: 7793.81631
+  tps: 7571.36913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-49982"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Heartpierce-50641"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofLunarFury-47670"
  value: {
-  dps: 8196.28059
-  tps: 7987.36336
+  dps: 8193.78867
+  tps: 7970.12207
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdolofMutilation-47668"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCorruptor-45509"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheCryingMoon-50456"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheLunarEclipse-50457"
  value: {
   dps: 8197.02416
-  tps: 7987.85784
+  tps: 7973.69858
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheRavenGoddess-32387"
  value: {
-  dps: 7996.70846
-  tps: 7786.36163
+  dps: 7954.13695
+  tps: 7726.32767
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheUnseenMoon-33510"
  value: {
-  dps: 7962.11715
-  tps: 7751.50018
+  dps: 7939.56333
+  tps: 7710.90886
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IdoloftheWhiteStag-32257"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7802.78821
-  tps: 7596.48642
+  dps: 7780.7358
+  tps: 7556.39651
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7801.02483
-  tps: 7594.68532
+  dps: 7776.65072
+  tps: 7552.23597
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 7807.04002
-  tps: 7604.97055
+  tps: 7594.14239
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 4212.38652
-  tps: 3990.34363
+  dps: 3325.1585
+  tps: 3074.3262
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LasherweaveRegalia"
  value: {
-  dps: 8882.27797
-  tps: 8674.43605
+  dps: 8882.13535
+  tps: 8668.53392
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50179"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-LastWord-50708"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7791.17038
-  tps: 7584.63052
+  dps: 7769.00199
+  tps: 7544.42463
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 4441.82214
-  tps: 4217.9731
+  dps: 3532.11973
+  tps: 3280.69848
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Malfurion'sRegalia"
  value: {
-  dps: 7381.07699
-  tps: 7171.8566
+  dps: 7311.64575
+  tps: 7081.95023
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7802.60706
-  tps: 7597.75013
+  dps: 7765.2529
+  tps: 7543.78167
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7865.475
-  tps: 7654.90705
+  dps: 7848.08693
+  tps: 7619.74732
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-49992"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Nibelung-50648"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongBattlegear"
  value: {
-  dps: 4217.89703
-  tps: 3995.03178
+  dps: 3295.08198
+  tps: 3043.42823
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-NightsongGarb"
  value: {
-  dps: 7204.47385
-  tps: 6997.14498
+  dps: 7145.78705
+  tps: 6917.52612
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 8156.24811
-  tps: 7944.05628
+  dps: 8090.50984
+  tps: 7857.72451
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 8217.79739
-  tps: 8004.75287
+  dps: 8151.57068
+  tps: 7917.93265
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 8019.34876
-  tps: 7809.27931
+  dps: 7991.62621
+  tps: 7763.05993
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7588.57506
+  dps: 7774.85337
+  tps: 7549.84734
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50339"
  value: {
   dps: 7965.7035
-  tps: 7755.77618
+  tps: 7741.26745
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SliverofPureIce-50346"
  value: {
   dps: 8001.10333
-  tps: 7790.54149
+  tps: 7776.3861
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7818.79418
-  tps: 7610.1472
+  dps: 7796.5507
+  tps: 7569.86623
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SouloftheDead-40382"
  value: {
   dps: 7825.18439
-  tps: 7623.82833
+  tps: 7612.42111
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SparkofLife-37657"
  value: {
   dps: 7797.85308
-  tps: 7591.16218
+  tps: 7576.72397
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-StormshroudArmor"
  value: {
-  dps: 4767.3513
-  tps: 4535.87505
+  dps: 3755.47804
+  tps: 3493.57264
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7729.53668
-  tps: 7523.27858
+  dps: 7707.55593
+  tps: 7483.26034
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TearsoftheVanquished-47215"
  value: {
   dps: 7767.28282
-  tps: 7562.29931
+  tps: 7550.04333
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartHarness"
  value: {
-  dps: 3229.59276
-  tps: 3013.32738
+  dps: 2562.53164
+  tps: 2320.97648
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderheartRegalia"
  value: {
-  dps: 5197.86893
-  tps: 4980.67339
+  dps: 4098.79691
+  tps: 3847.77797
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7795.75977
-  tps: 7589.25514
+  dps: 7768.94783
+  tps: 7543.94637
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7686.04479
-  tps: 7480.95072
+  dps: 7664.19206
+  tps: 7441.06048
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7838.70155
-  tps: 7631.02532
+  dps: 7811.73815
+  tps: 7585.56509
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7830.1132
-  tps: 7622.67128
+  dps: 7803.18008
+  tps: 7577.24134
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7908.46773
-  tps: 7702.36962
+  dps: 7893.44177
+  tps: 7667.96735
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7830.1132
-  tps: 7622.67128
+  dps: 7803.18008
+  tps: 7577.24134
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7838.70155
-  tps: 7631.02532
+  dps: 7811.73815
+  tps: 7585.56509
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4853.02562
-  tps: 4623.76697
+  dps: 3710.25708
+  tps: 3448.51502
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 8370.21405
-  tps: 8157.22477
+  dps: 8343.76565
+  tps: 8114.08149
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7827.38226
-  tps: 7613.25014
+  dps: 7805.52953
+  tps: 7573.35991
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
-  dps: 7919.29787
-  tps: 7709.43126
+  dps: 7896.82323
+  tps: 7668.91913
  }
 }
 dps_results: {
  key: "TestBalance-Average-Default"
  value: {
-  dps: 8095.01729
-  tps: 7886.05322
+  dps: 8063.45425
+  tps: 7836.1451
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p1-Default-basic_p3-FullBuffs-LongMultiTarget"
  value: {
   dps: 11434.28206
-  tps: 13611.20688
+  tps: 13284.21176
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p1-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8027.33723
-  tps: 7817.47062
+  dps: 8004.44252
+  tps: 7776.53841
  }
 }
 dps_results: {
@@ -995,14 +995,14 @@ dps_results: {
  key: "TestBalance-Settings-Tauren-p2-Default-basic_p3-FullBuffs-LongMultiTarget"
  value: {
   dps: 14057.32487
-  tps: 16410.5015
+  tps: 16284.54014
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p2-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
   dps: 9849.30409
-  tps: 9611.53795
+  tps: 9605.61352
  }
 }
 dps_results: {
@@ -1037,14 +1037,14 @@ dps_results: {
  key: "TestBalance-Settings-Tauren-p3_alliance-Default-basic_p3-FullBuffs-LongMultiTarget"
  value: {
   dps: 16434.76186
-  tps: 19011.8321
+  tps: 18978.78217
  }
 }
 dps_results: {
  key: "TestBalance-Settings-Tauren-p3_alliance-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
   dps: 11470.83985
-  tps: 11234.92914
+  tps: 11232.87102
  }
 }
 dps_results: {
@@ -1078,7 +1078,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7989.30984
-  tps: 7817.47062
+  dps: 7966.41513
+  tps: 7776.53841
  }
 }

--- a/sim/druid/balance/TestBalancePhase3.results
+++ b/sim/druid/balance/TestBalancePhase3.results
@@ -46,51 +46,51 @@ character_stats_results: {
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 11269.14665
-  tps: 10984.34704
+  dps: 11268.78919
+  tps: 10981.22173
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 11314.73853
-  tps: 11028.74168
+  dps: 11314.38107
+  tps: 11025.61637
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AshtongueTalismanofEquilibrium-32486"
  value: {
-  dps: 11010.24933
-  tps: 10734.09025
+  dps: 11009.89186
+  tps: 10730.96493
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-AustereEarthsiegeDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10899.62356
-  tps: 10621.01305
+  dps: 10899.2661
+  tps: 10617.88774
   hps: 100.88622
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10899.62356
-  tps: 10621.01305
+  dps: 10899.2661
+  tps: 10617.88774
   hps: 100.88622
  }
 }
@@ -98,869 +98,869 @@ dps_results: {
  key: "TestBalancePhase3-AllItems-BeamingEarthsiegeDiamond"
  value: {
   dps: 11150.14202
-  tps: 10870.76522
+  tps: 10867.74801
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 8547.19742
-  tps: 8278.12918
+  dps: 8473.83529
+  tps: 8182.53045
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 11177.43079
-  tps: 10680.60374
+  tps: 10677.185
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-BrutalGladiator'sIdolofResolve-35019"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
   hps: 64
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 11128.73761
-  tps: 10857.01717
+  dps: 11128.38015
+  tps: 10854.64576
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Death-42990"
  value: {
   dps: 11109.89642
-  tps: 10837.90699
+  tps: 10835.55902
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 11027.54553
-  tps: 10762.55209
+  dps: 11027.18807
+  tps: 10758.00939
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeadlyGladiator'sIdolofResolve-42588"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Death'sChoice-47464"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10949.99552
-  tps: 10676.52344
+  dps: 10949.63805
+  tps: 10673.43895
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DestructiveSkyflareDiamond"
  value: {
   dps: 11156.04233
-  tps: 10876.07709
+  tps: 10872.64518
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50348"
  value: {
   dps: 11604.62075
-  tps: 11323.26197
+  tps: 11319.76784
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DislodgedForeignObject-50353"
  value: {
   dps: 11508.79833
-  tps: 11231.1724
+  tps: 11227.07258
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerBattlegear"
  value: {
-  dps: 6973.25205
-  tps: 6713.18124
+  dps: 5207.27965
+  tps: 4902.59843
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-DreamwalkerGarb"
  value: {
-  dps: 8939.88027
-  tps: 8682.28361
+  dps: 8939.8496
+  tps: 8673.34596
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EffulgentSkyflareDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 11215.92686
-  tps: 10934.61922
+  tps: 10931.63624
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticSkyflareDiamond"
  value: {
   dps: 11150.14202
-  tps: 10870.07428
+  tps: 10866.64236
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 11150.45543
-  tps: 10870.31809
+  tps: 10866.95572
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EphemeralSnowflake-50260"
  value: {
   dps: 11052.47405
-  tps: 10780.94588
+  tps: 10778.21145
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EternalEarthsiegeDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 11187.01494
-  tps: 10914.76192
+  tps: 10912.43115
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 11395.09925
-  tps: 11120.31334
+  dps: 11394.74179
+  tps: 11117.8287
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10932.62037
-  tps: 10660.4377
+  dps: 10932.2629
+  tps: 10657.88458
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 11128.22631
-  tps: 10847.12725
+  dps: 11127.86884
+  tps: 10844.00193
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForgeEmber-37660"
  value: {
-  dps: 11291.49426
-  tps: 11017.8881
+  dps: 11291.13679
+  tps: 11015.27151
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornSkyflareDiamond"
  value: {
   dps: 11177.43079
-  tps: 10895.43348
+  tps: 10892.01475
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 11167.48603
-  tps: 10885.7579
+  tps: 10882.33917
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuriousGladiator'sIdolofResolve-42589"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-FuturesightRune-38763"
  value: {
-  dps: 11056.37655
-  tps: 10776.0876
+  dps: 11056.01909
+  tps: 10772.96229
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 7345.51011
-  tps: 7087.20135
+  dps: 5763.93505
+  tps: 5462.19704
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Gladiator'sWildhide"
  value: {
-  dps: 9421.1293
-  tps: 9131.96127
+  dps: 9421.0962
+  tps: 9124.48969
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 11291.94259
-  tps: 11006.54436
+  dps: 11291.58513
+  tps: 11003.41905
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 11343.75154
-  tps: 11056.99282
+  dps: 11343.39408
+  tps: 11053.8675
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-GnomishLightningGenerator-41121"
  value: {
   dps: 11118.60089
-  tps: 10842.62389
+  tps: 10840.47833
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-HatefulGladiator'sIdolofResolve-42587"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-49982"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Heartpierce-50641"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdolofMutilation-47668"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCorruptor-45509"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheCryingMoon-50456"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheLunarEclipse-50457"
  value: {
   dps: 11559.07233
-  tps: 11274.79898
+  tps: 11271.27671
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheRavenGoddess-32387"
  value: {
   dps: 11270.9935
-  tps: 10981.39902
+  tps: 10976.53923
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheUnseenMoon-33510"
  value: {
   dps: 11263.02834
-  tps: 10973.33868
+  tps: 10968.42127
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IdoloftheWhiteStag-32257"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 11297.29589
-  tps: 11016.74889
+  dps: 11296.93842
+  tps: 11013.62358
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveSkyflareDiamond"
  value: {
   dps: 11150.14202
-  tps: 10870.07428
+  tps: 10866.64236
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 11150.45543
-  tps: 10870.31809
+  tps: 10866.95572
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 11164.08167
-  tps: 10887.8621
+  tps: 10886.04382
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveBattlegear"
  value: {
-  dps: 6933.15094
-  tps: 6671.99635
+  dps: 5335.30341
+  tps: 5032.67929
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LasherweaveRegalia"
  value: {
   dps: 10876.76857
-  tps: 10605.9472
+  tps: 10604.28022
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50179"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-LastWord-50708"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 11021.08221
-  tps: 10744.36106
+  dps: 11020.72475
+  tps: 10741.23575
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sBattlegear"
  value: {
-  dps: 7496.95312
-  tps: 7242.89524
+  dps: 5827.71718
+  tps: 5531.00015
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Malfurion'sRegalia"
  value: {
   dps: 9647.20726
-  tps: 9375.4353
+  tps: 9366.23983
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 11090.7671
-  tps: 10819.82005
+  dps: 11090.40964
+  tps: 10817.1106
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 11143.11302
-  tps: 10861.80086
+  dps: 11142.93429
+  tps: 10859.1269
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-49992"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Nibelung-50648"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongBattlegear"
  value: {
-  dps: 7447.81374
-  tps: 7192.33409
+  dps: 5640.78249
+  tps: 5339.74455
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-NightsongGarb"
  value: {
   dps: 9241.71896
-  tps: 8971.5406
+  tps: 8963.84881
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthshatterDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PowerfulEarthsiegeDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47316"
  value: {
   dps: 11455.52105
-  tps: 11171.73021
+  tps: 11168.2983
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ReignoftheDead-47477"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 11504.18939
-  tps: 11218.83532
+  tps: 11215.41658
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RelentlessGladiator'sIdolofResolve-42591"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RevitalizingSkyflareDiamond"
  value: {
   dps: 11127.707
-  tps: 10846.52265
+  tps: 10843.21195
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SavageGladiator'sIdolofResolve-42574"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 11225.62714
-  tps: 10943.32755
+  dps: 11225.26967
+  tps: 10940.84259
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 11267.0743
-  tps: 10983.74773
+  dps: 11266.71683
+  tps: 10981.31201
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SoulPreserver-37111"
  value: {
-  dps: 11053.62142
-  tps: 10774.48148
+  dps: 11053.26395
+  tps: 10771.35616
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SouloftheDead-40382"
  value: {
-  dps: 11131.94181
-  tps: 10862.80022
+  dps: 11131.58434
+  tps: 10860.86542
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SparkofLife-37657"
  value: {
   dps: 10995.58051
-  tps: 10719.24058
+  tps: 10716.83795
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 11062.85747
-  tps: 10789.3262
+  dps: 11062.7458
+  tps: 10786.54741
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-StormshroudArmor"
  value: {
-  dps: 8061.35777
-  tps: 7798.60106
+  dps: 7199.63373
+  tps: 6900.54324
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-SwiftWindfireDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10949.11614
-  tps: 10672.72049
+  dps: 10948.75867
+  tps: 10669.59517
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10967.82572
-  tps: 10695.48184
+  dps: 10967.46825
+  tps: 10693.22096
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10898.19457
-  tps: 10623.13612
+  dps: 10897.8371
+  tps: 10620.0108
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartHarness"
  value: {
-  dps: 4539.78207
-  tps: 4275.34037
+  dps: 3378.53779
+  tps: 3080.25795
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderheartRegalia"
  value: {
-  dps: 6946.97561
-  tps: 6690.53782
+  dps: 5411.389
+  tps: 5111.42384
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-ThunderingSkyflareDiamond"
  value: {
   dps: 11127.707
-  tps: 10847.05558
+  tps: 10843.63685
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 11062.85747
-  tps: 10789.3262
+  dps: 11062.7458
+  tps: 10786.54741
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11062.85747
-  tps: 10789.3262
+  dps: 11062.7458
+  tps: 10786.54741
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessSkyflareDiamond"
  value: {
   dps: 11177.43079
-  tps: 10895.43348
+  tps: 10892.01475
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 11167.48603
-  tps: 10885.7579
+  tps: 10882.33917
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TomeofArcanePhenomena-36972"
  value: {
   dps: 11171.19546
-  tps: 10894.43432
+  tps: 10891.56371
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 11167.48603
-  tps: 10885.7579
+  tps: 10882.33917
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-TrenchantEarthsiegeDiamond"
  value: {
   dps: 11177.43079
-  tps: 10895.43348
+  tps: 10892.01475
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 8151.96164
-  tps: 7889.34015
+  dps: 7012.24621
+  tps: 6710.44097
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 11360.92735
-  tps: 11078.38683
+  tps: 11075.21041
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-VengefulGladiator'sIdolofResolve-33947"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WingedTalisman-37844"
  value: {
-  dps: 11064.09174
-  tps: 10778.66206
+  dps: 11063.73427
+  tps: 10775.53674
  }
 }
 dps_results: {
  key: "TestBalancePhase3-AllItems-WrathfulGladiator'sIdolofResolve-51429"
  value: {
   dps: 11212.94161
-  tps: 10923.43088
+  tps: 10918.51348
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Average-Default"
  value: {
-  dps: 11672.64636
-  tps: 11392.76295
+  dps: 11672.61761
+  tps: 11389.87583
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-p3_alliance-Default-basic_p3-FullBuffs-LongMultiTarget"
  value: {
   dps: 16400.83037
-  tps: 19099.03764
+  tps: 19048.15683
  }
 }
 dps_results: {
  key: "TestBalancePhase3-Settings-Tauren-p3_alliance-Default-basic_p3-FullBuffs-LongSingleTarget"
  value: {
   dps: 11528.06738
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }
 dps_results: {
@@ -995,6 +995,6 @@ dps_results: {
  key: "TestBalancePhase3-SwitchInFrontOfTarget-Default"
  value: {
   dps: 11478.44276
-  tps: 11243.29698
+  tps: 11239.86507
  }
 }

--- a/sim/druid/force_of_nature.go
+++ b/sim/druid/force_of_nature.go
@@ -108,8 +108,7 @@ func (treant *TreantPet) Initialize() {
 func (treant *TreantPet) Reset(_ *core.Simulation) {
 }
 
-func (treant *TreantPet) OnGCDReady(_ *core.Simulation) {
-	treant.DoNothing()
+func (treant *TreantPet) ExecuteCustomRotation(_ *core.Simulation) {
 }
 
 // TODO : fix miss/dodge

--- a/sim/encounters/default_ai.go
+++ b/sim/encounters/default_ai.go
@@ -52,7 +52,7 @@ func (ai *DefaultAI) Reset(sim *core.Simulation) {
 
 }
 
-func (ai *DefaultAI) DoAction(sim *core.Simulation) {
+func (ai *DefaultAI) ExecuteCustomRotation(sim *core.Simulation) {
 	for _, ability := range ai.Abilities {
 		if sim.CurrentTime < ability.InitialCD {
 			continue

--- a/sim/encounters/icc/lichking25h_ai.go
+++ b/sim/encounters/icc/lichking25h_ai.go
@@ -133,25 +133,27 @@ func (ai *LichKing25HAI) registerSoulReaperSpell(target *core.Target) {
 	})
 }
 
-func (ai *LichKing25HAI) DoAction(sim *core.Simulation) {
-	if ai.Target.GCD.IsReady(sim) {
-		if ai.Target.CurrentTarget != nil {
-			if ai.SoulReaper.IsReady(sim) {
-				// Based on log analysis, Soul Reaper appears to have a ~75% chance to "proc" on every 1.62 second server tick once it is off cooldown.
-				// Note that analysis based only on the cast intervals supported a ~40% proc chance fit. However, many of the apparent delays in Soul Reaper casts are
-				// due to Defile and Infest casts that take priority when the cooldowns overlap. Once these CD conflicts are corrected for, the variance in Soul Reaper
-				// cast times is a fair bit lower. A more fleshed out boss AI would directly model the Defile and Infest casts, with more sophisticated APLs for tank CD
-				// usage in order to delay pre-emptive CDs when the player knows that a 2 second cast will take place before any potential Soul Reaper.
-				procRoll := sim.RandomFloat("Soul Reaper AI")
+func (ai *LichKing25HAI) ExecuteCustomRotation(sim *core.Simulation) {
+	if !ai.Target.GCD.IsReady(sim) {
+		return
+	}
 
-				if procRoll < 0.75 {
-					ai.SoulReaper.Cast(sim, ai.Target.CurrentTarget)
-					return
-				}
+	if ai.Target.CurrentTarget != nil {
+		if ai.SoulReaper.IsReady(sim) {
+			// Based on log analysis, Soul Reaper appears to have a ~75% chance to "proc" on every 1.62 second server tick once it is off cooldown.
+			// Note that analysis based only on the cast intervals supported a ~40% proc chance fit. However, many of the apparent delays in Soul Reaper casts are
+			// due to Defile and Infest casts that take priority when the cooldowns overlap. Once these CD conflicts are corrected for, the variance in Soul Reaper
+			// cast times is a fair bit lower. A more fleshed out boss AI would directly model the Defile and Infest casts, with more sophisticated APLs for tank CD
+			// usage in order to delay pre-emptive CDs when the player knows that a 2 second cast will take place before any potential Soul Reaper.
+			procRoll := sim.RandomFloat("Soul Reaper AI")
+
+			if procRoll < 0.75 {
+				ai.SoulReaper.Cast(sim, ai.Target.CurrentTarget)
+				return
 			}
 		}
-
-		// Lich King follows the standard Classic WoW boss AI behavior of evaluating actions on a 1.62 second server tick.
-		ai.Target.WaitUntil(sim, sim.CurrentTime+time.Millisecond*1620)
 	}
+
+	// Lich King follows the standard Classic WoW boss AI behavior of evaluating actions on a 1.62 second server tick.
+	ai.Target.WaitUntil(sim, sim.CurrentTime+time.Millisecond*1620)
 }

--- a/sim/encounters/icc/sindragosa25h_ai.go
+++ b/sim/encounters/icc/sindragosa25h_ai.go
@@ -205,10 +205,8 @@ func (ai *Sindragosa25HAI) registerMysticBuffetAuras() {
 }
 
 func (ai *Sindragosa25HAI) registerFrostAuraSpell(target *core.Target) {
-	actionID := core.ActionID{SpellID: 70084}
-
 	ai.FrostAura = target.RegisterSpell(core.SpellConfig{
-		ActionID:    actionID,
+		ActionID:    core.ActionID{SpellID: 70084},
 		SpellSchool: core.SpellSchoolFrost,
 		ProcMask:    core.ProcMaskSpellDamage,
 		Flags:       core.SpellFlagNone,
@@ -310,23 +308,23 @@ func (ai *Sindragosa25HAI) registerFrostBreathSpell(target *core.Target) {
 	})
 }
 
-func (ai *Sindragosa25HAI) DoAction(sim *core.Simulation) {
-	if ai.Target.GCD.IsReady(sim) {
-		// Cast Frost Aura once at the start of the encounter.
-		if sim.CurrentTime < time.Millisecond*1620 {
-			ai.FrostAura.Cast(sim, &ai.Target.Unit)
-			return
-		}
-
-		if ai.Target.CurrentTarget != nil {
-			if ai.FrostBreath.IsReady(sim) {
-				ai.Target.Unit.AutoAttacks.StopMeleeUntil(sim, sim.CurrentTime+time.Millisecond*1500, false)
-				ai.FrostBreath.Cast(sim, ai.Target.CurrentTarget)
-				return
-			}
-		}
-
-		// Sindragosa follows the standard Classic WoW boss AI behavior of evaluating actions on a 1.62 second server tick.
-		ai.Target.WaitUntil(sim, sim.CurrentTime+time.Millisecond*1620)
+func (ai *Sindragosa25HAI) ExecuteCustomRotation(sim *core.Simulation) {
+	if !ai.Target.GCD.IsReady(sim) {
+		return
 	}
+
+	// Cast Frost Aura once at the start of the encounter.
+	if sim.CurrentTime < time.Millisecond*1620 {
+		ai.FrostAura.Cast(sim, &ai.Target.Unit)
+		return
+	}
+
+	if ai.Target.CurrentTarget != nil && ai.FrostBreath.IsReady(sim) {
+		ai.Target.Unit.AutoAttacks.StopMeleeUntil(sim, sim.CurrentTime+time.Millisecond*1500, false)
+		ai.FrostBreath.Cast(sim, ai.Target.CurrentTarget)
+		return
+	}
+
+	// Sindragosa follows the standard Classic WoW boss AI behavior of evaluating actions on a 1.62 second server tick.
+	ai.Target.WaitUntil(sim, sim.CurrentTime+time.Millisecond*1620)
 }

--- a/sim/encounters/naxxramas/kelthuzad25_ai.go
+++ b/sim/encounters/naxxramas/kelthuzad25_ai.go
@@ -57,6 +57,5 @@ func (ai *KelThuzad25AI) Initialize(target *core.Target, config *proto.Target) {
 func (ai *KelThuzad25AI) Reset(*core.Simulation) {
 }
 
-func (ai *KelThuzad25AI) DoAction(sim *core.Simulation) {
-	ai.Target.DoNothing()
+func (ai *KelThuzad25AI) ExecuteCustomRotation(sim *core.Simulation) {
 }

--- a/sim/encounters/naxxramas/loatheb25_ai.go
+++ b/sim/encounters/naxxramas/loatheb25_ai.go
@@ -57,6 +57,5 @@ func (ai *Loatheb25AI) Initialize(target *core.Target, config *proto.Target) {
 func (ai *Loatheb25AI) Reset(*core.Simulation) {
 }
 
-func (ai *Loatheb25AI) DoAction(sim *core.Simulation) {
-	ai.Target.DoNothing()
+func (ai *Loatheb25AI) ExecuteCustomRotation(sim *core.Simulation) {
 }

--- a/sim/encounters/naxxramas/patchwerk10_ai.go
+++ b/sim/encounters/naxxramas/patchwerk10_ai.go
@@ -123,9 +123,8 @@ func (ai *Patchwerk10AI) registerFrenzySpell(target *core.Target) {
 	})
 }
 
-func (ai *Patchwerk10AI) DoAction(sim *core.Simulation) {
+func (ai *Patchwerk10AI) ExecuteCustomRotation(sim *core.Simulation) {
 	if ai.Target.CurrentTarget == nil {
-		ai.Target.DoNothing()
 		return
 	}
 

--- a/sim/encounters/naxxramas/patchwerk25_ai.go
+++ b/sim/encounters/naxxramas/patchwerk25_ai.go
@@ -124,13 +124,11 @@ func (ai *Patchwerk25AI) registerFrenzySpell(target *core.Target) {
 	})
 }
 
-func (ai *Patchwerk25AI) DoAction(sim *core.Simulation) {
+func (ai *Patchwerk25AI) ExecuteCustomRotation(sim *core.Simulation) {
 	if ai.Target.CurrentTarget == nil {
-		ai.Target.DoNothing()
 		return
 	}
 
-	ai.Target.DoNothing()
 	// TODO: Re-enable Frenzy when we have a feature to flag for tank cooldown timing
 	//       Otherwise users get confused why the default settings say they die a lot...
 	//if ai.Frenzy.IsReady(sim) && sim.GetRemainingDurationPercent() < 0.05 {

--- a/sim/encounters/naxxramas/thaddius25_ai.go
+++ b/sim/encounters/naxxramas/thaddius25_ai.go
@@ -57,6 +57,5 @@ func (ai *Thaddius25AI) Initialize(target *core.Target, config *proto.Target) {
 func (ai *Thaddius25AI) Reset(*core.Simulation) {
 }
 
-func (ai *Thaddius25AI) DoAction(sim *core.Simulation) {
-	ai.Target.DoNothing()
+func (ai *Thaddius25AI) ExecuteCustomRotation(sim *core.Simulation) {
 }

--- a/sim/encounters/toc/gormok25h_ai.go
+++ b/sim/encounters/toc/gormok25h_ai.go
@@ -225,16 +225,14 @@ func (ai *Gormok25HAI) registerRisingAngerSpell(target *core.Target) {
 		CritMultiplier:   1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-
 			ai.RisingAngerAura.Activate(sim)
 			ai.RisingAngerAura.AddStack(sim)
-
 		},
 	})
 
 }
 
-func (ai *Gormok25HAI) DoAction(sim *core.Simulation) {
+func (ai *Gormok25HAI) ExecuteCustomRotation(sim *core.Simulation) {
 	if ai.RisingAnger.IsReady(sim) && sim.CurrentTime >= ai.RisingAnger.CD.Duration && ai.Target.GCD.IsReady(sim) {
 		ai.RisingAnger.Cast(sim, &ai.Target.Unit)
 		return

--- a/sim/encounters/ulduar/algalon25_ai.go
+++ b/sim/encounters/ulduar/algalon25_ai.go
@@ -190,7 +190,7 @@ func (ai *Algalon25AI) registerCosmicSmashSpell(target *core.Target) {
 	})
 }
 
-func (ai *Algalon25AI) DoAction(sim *core.Simulation) {
+func (ai *Algalon25AI) ExecuteCustomRotation(sim *core.Simulation) {
 	if ai.Target.CurrentTarget != nil {
 		if ai.BlackHoleExplosion.IsReady(sim) && sim.CurrentTime >= ai.BlackHoleExplosion.CD.Duration {
 			ai.BlackHoleExplosion.Cast(sim, ai.Target.CurrentTarget)
@@ -237,5 +237,4 @@ func (ai *Algalon25AI) DoAction(sim *core.Simulation) {
 
 		ai.Target.WaitUntil(sim, nextEventAt)
 	}
-
 }

--- a/sim/encounters/ulduar/hodir_ai.go
+++ b/sim/encounters/ulduar/hodir_ai.go
@@ -380,8 +380,7 @@ func (ai *HodirAI) registerFrozenBlowSpell(target *core.Target) {
 	})
 }
 
-func (ai *HodirAI) DoAction(sim *core.Simulation) {
-
+func (ai *HodirAI) ExecuteCustomRotation(sim *core.Simulation) {
 	singedStacks := ai.Singed.GetStacks()
 
 	if sim.CurrentTime >= ai.ToastyFireTime && ai.HasCampfire {

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -46,935 +46,935 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 7189.55017
-  tps: 5146.60022
+  dps: 7197.32187
+  tps: 5160.06989
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 6351.06055
-  tps: 4271.57821
+  dps: 6314.98023
+  tps: 4250.90014
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6445.22599
-  tps: 4357.20203
+  dps: 6409.83677
+  tps: 4337.22027
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6286.66525
-  tps: 4223.34325
+  dps: 6251.14993
+  tps: 4203.17379
   hps: 92.16151
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6286.66525
-  tps: 4223.34325
+  dps: 6251.14993
+  tps: 4203.17379
   hps: 92.16151
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 6396.77616
-  tps: 4303.04304
+  dps: 6348.57596
+  tps: 4268.51037
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6259.74234
-  tps: 4211.60452
+  dps: 6220.61602
+  tps: 4175.45993
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 5956.25614
-  tps: 3885.95381
+  dps: 5959.43317
+  tps: 3887.6049
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6139.561
-  tps: 4102.10945
+  dps: 6122.30934
+  tps: 4081.09283
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6128.90856
-  tps: 4094.20794
+  dps: 6111.68056
+  tps: 4073.22271
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 5347.40655
-  tps: 3606.1824
+  dps: 5302.37331
+  tps: 3567.90179
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5178.7472
-  tps: 3488.18028
+  dps: 5145.56324
+  tps: 3447.26593
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4192.28021
+  dps: 6345.67184
+  tps: 4180.69202
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 6468.58218
-  tps: 4372.96544
+  dps: 6434.86988
+  tps: 4352.94044
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 6468.58218
-  tps: 4372.96544
+  dps: 6434.86988
+  tps: 4352.94044
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 6461.27995
-  tps: 4367.9129
+  dps: 6428.84276
+  tps: 4349.18894
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 5907.22488
-  tps: 3950.85265
+  dps: 5905.25388
+  tps: 3947.63265
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6352.38917
-  tps: 4284.49958
+  dps: 6336.4783
+  tps: 4278.94024
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6411.33178
-  tps: 4342.9194
+  dps: 6381.59672
+  tps: 4325.13811
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 6450.80058
-  tps: 4358.07873
+  dps: 6423.41895
+  tps: 4331.84582
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6596.07139
-  tps: 4468.58944
+  dps: 6593.38249
+  tps: 4461.60909
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6346.27903
-  tps: 4275.50887
+  dps: 6326.92854
+  tps: 4267.61226
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6606.84889
-  tps: 4507.70293
+  dps: 6589.50554
+  tps: 4498.95047
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6661.71513
-  tps: 4549.0504
+  dps: 6625.61118
+  tps: 4528.9708
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6385.8303
-  tps: 4293.61548
+  dps: 6355.68867
+  tps: 4275.63458
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 6356.65227
-  tps: 4306.65823
+  dps: 6326.64876
+  tps: 4278.28129
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6358.24714
-  tps: 4292.60208
+  dps: 6308.5662
+  tps: 4258.15396
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 6382.70364
-  tps: 4287.21809
+  dps: 6345.817
+  tps: 4267.51129
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6383.87779
-  tps: 4290.51073
+  dps: 6352.08341
+  tps: 4272.4296
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6383.56298
-  tps: 4290.19593
+  dps: 6351.40551
+  tps: 4271.75169
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6329.96912
-  tps: 4268.23351
+  dps: 6314.80509
+  tps: 4255.68025
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6397.56348
-  tps: 4329.02283
+  dps: 6370.48053
+  tps: 4311.95304
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6348.62671
-  tps: 4280.09563
+  dps: 6322.32127
+  tps: 4263.98179
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6323.53397
-  tps: 4255.60672
+  dps: 6297.45261
+  tps: 4237.26251
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6333.73943
-  tps: 4265.7748
+  dps: 6301.87893
+  tps: 4246.92003
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6446.16425
-  tps: 4342.21263
+  dps: 6410.06931
+  tps: 4321.70728
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 6239.18169
-  tps: 4311.53445
+  dps: 6190.78077
+  tps: 4274.46543
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6385.42978
-  tps: 4317.11389
+  dps: 6355.88006
+  tps: 4299.55288
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5007.9512
-  tps: 3331.51676
+  dps: 4972.55047
+  tps: 3310.6859
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 6516.98905
-  tps: 4409.1096
+  dps: 6483.07838
+  tps: 4388.97121
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 6518.03006
-  tps: 4409.8869
+  dps: 6484.11512
+  tps: 4389.74606
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 6286.85592
-  tps: 4223.66401
+  dps: 6251.46949
+  tps: 4203.53965
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6383.87779
-  tps: 4290.51073
+  dps: 6352.08341
+  tps: 4272.4296
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6383.56298
-  tps: 4290.19593
+  dps: 6351.40551
+  tps: 4271.75169
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6431.12177
-  tps: 4348.46023
+  dps: 6395.27927
+  tps: 4328.02447
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 6428.01385
-  tps: 4331.57618
+  dps: 6408.78961
+  tps: 4317.91257
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6393.40482
-  tps: 4296.29357
+  dps: 6368.45444
+  tps: 4281.51886
   hps: 11.19844
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50179"
  value: {
-  dps: 6468.58218
-  tps: 4372.96544
+  dps: 6434.86988
+  tps: 4352.94044
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 6468.58218
-  tps: 4372.96544
+  dps: 6434.86988
+  tps: 4352.94044
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6365.09622
-  tps: 4295.9373
+  dps: 6340.63038
+  tps: 4279.91505
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6400.4214
-  tps: 4324.6905
+  dps: 6365.00511
+  tps: 4299.12211
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-49992"
  value: {
-  dps: 6580.08633
-  tps: 4464.05469
+  dps: 6533.42725
+  tps: 4423.658
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Nibelung-50648"
  value: {
-  dps: 6584.83396
-  tps: 4467.73345
+  dps: 6543.64555
+  tps: 4433.45342
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6386.48279
-  tps: 4289.4204
+  dps: 6363.07214
+  tps: 4277.59966
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6390.58701
-  tps: 4292.46969
+  dps: 6367.16633
+  tps: 4280.64522
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 6295.36214
-  tps: 4232.06123
+  dps: 6259.37135
+  tps: 4211.27855
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 6296.46735
-  tps: 4233.16644
+  dps: 6260.38535
+  tps: 4212.29254
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 6468.58218
-  tps: 4372.96544
+  dps: 6434.86988
+  tps: 4352.94044
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 6383.74732
-  tps: 4289.36031
+  dps: 6339.93997
+  tps: 4263.37683
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 6324.00193
-  tps: 4298.57797
+  dps: 6318.27477
+  tps: 4280.24257
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 6659.49479
-  tps: 4556.82769
+  dps: 6642.89723
+  tps: 4539.98784
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6312.09667
-  tps: 4255.05637
+  dps: 6283.87
+  tps: 4234.35501
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6323.05908
-  tps: 4265.06725
+  dps: 6290.07926
+  tps: 4240.78224
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 6358.326
-  tps: 4289.36711
+  dps: 6338.8084
+  tps: 4273.18981
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 6340.75387
-  tps: 4256.57801
+  dps: 6302.15173
+  tps: 4231.10146
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6418.43226
-  tps: 4299.14357
+  dps: 6391.20434
+  tps: 4271.2163
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StormshroudArmor"
  value: {
-  dps: 5040.18249
-  tps: 3344.5557
+  dps: 4997.49522
+  tps: 3318.23375
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6390.58701
-  tps: 4292.46969
+  dps: 6367.16633
+  tps: 4280.64522
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6386.48279
-  tps: 4289.4204
+  dps: 6363.07214
+  tps: 4277.59966
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6379.30042
-  tps: 4284.08413
+  dps: 6355.90731
+  tps: 4272.26993
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6360.08744
-  tps: 4285.41065
+  dps: 6322.32822
+  tps: 4255.13461
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheFistsofFury"
  value: {
-  dps: 6169.33066
-  tps: 4128.89411
+  dps: 6158.36178
+  tps: 4109.99627
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 6324.8676
-  tps: 4256.01175
+  dps: 6301.45934
+  tps: 4231.4124
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6385.39411
-  tps: 4294.18129
+  dps: 6374.32513
+  tps: 4274.1496
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6331.98589
-  tps: 4234.78646
+  dps: 6306.02901
+  tps: 4208.09957
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6331.98589
-  tps: 4234.78646
+  dps: 6306.02901
+  tps: 4208.09957
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6316.66525
-  tps: 4242.04095
+  dps: 6298.01351
+  tps: 4232.35406
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6369.03989
-  tps: 4276.4609
+  dps: 6345.67184
+  tps: 4264.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 5271.36867
-  tps: 3547.09403
+  dps: 5226.8764
+  tps: 3507.00162
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6219.39293
-  tps: 4181.13578
+  dps: 6195.29741
+  tps: 4157.71066
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 6429.18968
-  tps: 4399.23869
+  dps: 6402.6944
+  tps: 4379.65746
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6286.88156
-  tps: 4223.68964
+  dps: 6251.49513
+  tps: 4203.56528
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 6829.142
-  tps: 4753.53995
+  dps: 6795.20642
+  tps: 4730.02288
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 7040.87357
-  tps: 4966.4633
+  dps: 7016.25474
+  tps: 4949.40737
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 6432.41489
-  tps: 4349.52094
+  dps: 6402.75082
+  tps: 4323.09815
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14097.37708
-  tps: 13406.96699
+  dps: 14072.16476
+  tps: 13376.49652
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6362.69653
-  tps: 4372.35982
+  dps: 6337.39469
+  tps: 4357.00993
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7622.66902
-  tps: 5202.59373
+  dps: 7629.78667
+  tps: 5199.59208
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7563.20544
-  tps: 8710.11183
+  dps: 7545.12512
+  tps: 8694.20004
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3048.9954
-  tps: 2407.25718
+  dps: 3052.64689
+  tps: 2411.55002
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-p1_sv-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3493.44407
-  tps: 2752.32679
+  dps: 3494.45904
+  tps: 2756.05951
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14281.06531
-  tps: 13474.96368
+  dps: 14249.00169
+  tps: 13444.48168
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6468.58218
-  tps: 4372.96544
+  dps: 6434.86988
+  tps: 4352.94044
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 7771.84444
-  tps: 5212.4213
+  dps: 7783.04709
+  tps: 5210.9797
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7635.84628
-  tps: 8750.03446
+  dps: 7636.2226
+  tps: 8754.97338
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3077.81941
-  tps: 2403.24647
+  dps: 3086.14668
+  tps: 2413.58804
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-p1_sv-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3552.2038
-  tps: 2765.22516
+  dps: 3554.06148
+  tps: 2769.83856
  }
 }
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6284.44596
-  tps: 4358.35418
+  dps: 6266.98567
+  tps: 4338.27626
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -46,1019 +46,1019 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 8465.61535
-  tps: 7545.76939
+  dps: 8469.069
+  tps: 7548.41719
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7158.13438
-  tps: 6242.84146
+  dps: 7133.6007
+  tps: 6220.74708
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7254.1853
-  tps: 6334.21428
+  dps: 7230.65197
+  tps: 6313.15047
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7088.76691
-  tps: 6179.72749
-  hps: 91.71984
+  dps: 7064.87473
+  tps: 6158.16398
+  hps: 91.55526
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7088.76691
-  tps: 6179.72749
-  hps: 91.71984
+  dps: 7064.87473
+  tps: 6158.16398
+  hps: 91.55526
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7197.6661
-  tps: 6273.30902
+  dps: 7185.11124
+  tps: 6259.24451
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7151.89178
-  tps: 6240.53161
+  dps: 7099.50017
+  tps: 6189.51751
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 6685.72102
-  tps: 5771.48879
+  dps: 6688.19136
+  tps: 5772.74984
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 6977.0213
-  tps: 6074.72142
+  dps: 6962.14413
+  tps: 6058.43346
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 6964.18144
-  tps: 6063.07616
+  dps: 6949.34639
+  tps: 6046.83085
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6127.59208
-  tps: 5344.57135
+  dps: 6103.81836
+  tps: 5320.93754
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5872.34043
-  tps: 5113.54385
+  dps: 5858.34291
+  tps: 5102.1041
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6125.304
+  dps: 7157.36434
+  tps: 6109.41972
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7336.91871
-  tps: 6411.03702
+  dps: 7321.55788
+  tps: 6395.60841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7336.91871
-  tps: 6411.03702
+  dps: 7321.55788
+  tps: 6395.60841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7332.52556
-  tps: 6408.05146
+  dps: 7316.1637
+  tps: 6391.58223
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6611.54186
-  tps: 5734.0298
+  dps: 6604.49664
+  tps: 5728.08336
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7210.76011
-  tps: 6300.54725
+  dps: 7202.65584
+  tps: 6292.11585
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7244.08275
-  tps: 6332.22156
+  dps: 7236.56922
+  tps: 6324.55008
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7347.03922
-  tps: 6416.09355
+  dps: 7318.64855
+  tps: 6389.48893
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7530.84745
-  tps: 6591.18569
+  dps: 7507.32777
+  tps: 6566.97367
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7156.21204
-  tps: 6243.00528
+  dps: 7131.98092
+  tps: 6219.46741
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7478.73839
-  tps: 6552.7754
+  dps: 7468.68394
+  tps: 6542.36439
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7516.71526
-  tps: 6589.2685
+  dps: 7507.73343
+  tps: 6579.32394
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7194.6279
-  tps: 6270.16878
+  dps: 7178.60186
+  tps: 6254.03537
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7222.5124
-  tps: 6311.48243
+  dps: 7225.35753
+  tps: 6311.60021
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7206.17663
-  tps: 6296.94442
+  dps: 7194.52294
+  tps: 6286.06814
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7186.82234
-  tps: 6260.65252
+  dps: 7173.43915
+  tps: 6247.84387
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7193.35034
-  tps: 6268.87625
+  dps: 7177.32429
+  tps: 6252.74283
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7190.8901
-  tps: 6266.41601
+  dps: 7174.86302
+  tps: 6250.28156
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7174.29431
-  tps: 6270.34711
+  dps: 7163.83025
+  tps: 6257.85975
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7261.00872
-  tps: 6349.8129
+  dps: 7254.58238
+  tps: 6342.50953
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7193.57376
-  tps: 6281.9538
+  dps: 7188.69225
+  tps: 6276.63648
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7126.94307
-  tps: 6214.41438
+  dps: 7113.65297
+  tps: 6203.57371
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7170.92338
-  tps: 6259.50246
+  dps: 7154.72492
+  tps: 6242.67744
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7280.11479
-  tps: 6353.25624
+  dps: 7255.34022
+  tps: 6330.96471
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7230.01254
-  tps: 6372.38081
+  dps: 7215.72619
+  tps: 6354.39801
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7222.15052
-  tps: 6310.36505
+  dps: 7215.05418
+  tps: 6303.13626
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5556.18604
-  tps: 4799.84754
+  dps: 5521.23002
+  tps: 4769.02356
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 7394.85743
-  tps: 6463.66323
+  dps: 7379.36642
+  tps: 6448.10946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 7396.10343
-  tps: 6464.79498
+  dps: 7380.60961
+  tps: 6449.23851
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7088.88593
-  tps: 6179.70924
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7193.35034
-  tps: 6268.87625
+  dps: 7177.32429
+  tps: 6252.74283
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7190.8901
-  tps: 6266.41601
+  dps: 7174.86302
+  tps: 6250.28156
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7246.82741
-  tps: 6329.23605
+  dps: 7221.58837
+  tps: 6306.44549
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7247.15098
-  tps: 6321.23511
+  dps: 7240.17165
+  tps: 6314.87106
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7199.30937
-  tps: 6271.76728
+  dps: 7187.12254
+  tps: 6260.32118
   hps: 11.11942
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50179"
  value: {
-  dps: 7336.91871
-  tps: 6411.03702
+  dps: 7321.55788
+  tps: 6395.60841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 7336.91871
-  tps: 6411.03702
+  dps: 7321.55788
+  tps: 6395.60841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7088.90305
-  tps: 6179.72636
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7270.45526
-  tps: 6360.26937
+  dps: 7249.8966
+  tps: 6340.10177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7235.23523
-  tps: 6326.70417
+  dps: 7221.2669
+  tps: 6313.40304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-49992"
  value: {
-  dps: 7467.19102
-  tps: 6528.36572
+  dps: 7446.60059
+  tps: 6508.4271
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Nibelung-50648"
  value: {
-  dps: 7476.34279
-  tps: 6536.47328
+  dps: 7456.23283
+  tps: 6517.27887
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7195.03796
-  tps: 6267.78041
+  dps: 7178.06551
+  tps: 6251.54638
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7199.92075
-  tps: 6272.20583
+  dps: 7182.93638
+  tps: 6255.96069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7088.90305
-  tps: 6179.72636
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7097.99905
-  tps: 6188.79584
+  dps: 7075.3939
+  tps: 6168.63182
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7099.14216
-  tps: 6189.93895
+  dps: 7076.66999
+  tps: 6169.90791
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7336.91871
-  tps: 6411.03702
+  dps: 7321.55788
+  tps: 6395.60841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7177.90884
-  tps: 6252.08608
+  dps: 7166.92991
+  tps: 6239.75058
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7067.04257
-  tps: 6188.26738
+  dps: 7065.56974
+  tps: 6186.05793
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7609.79649
-  tps: 6682.57357
+  dps: 7602.49284
+  tps: 6674.67317
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7088.88186
-  tps: 6179.70517
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7141.54385
-  tps: 6231.41953
+  dps: 7122.48519
+  tps: 6214.97482
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7142.53225
-  tps: 6232.90696
+  dps: 7128.31833
+  tps: 6220.97492
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7212.62646
-  tps: 6301.92244
+  dps: 7202.30323
+  tps: 6291.2133
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 7212.20863
-  tps: 6298.56223
+  dps: 7180.82284
+  tps: 6264.66556
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7184.80251
-  tps: 6265.92638
+  dps: 7160.0461
+  tps: 6243.59296
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StormshroudArmor"
  value: {
-  dps: 5720.93674
-  tps: 4968.98786
+  dps: 5669.34177
+  tps: 4918.07828
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7199.92075
-  tps: 6272.20583
+  dps: 7182.93638
+  tps: 6255.96069
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7195.03796
-  tps: 6267.78041
+  dps: 7178.06551
+  tps: 6251.54638
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7186.49308
-  tps: 6260.03593
+  dps: 7169.5415
+  tps: 6243.82135
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7183.17643
-  tps: 6264.29646
+  dps: 7151.50767
+  tps: 6236.55343
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheFistsofFury"
  value: {
-  dps: 7009.30879
-  tps: 6106.93201
+  dps: 6994.61478
+  tps: 6089.58426
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7160.38869
-  tps: 6257.04214
+  dps: 7140.69531
+  tps: 6235.9288
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7201.06719
-  tps: 6276.21743
+  dps: 7186.19792
+  tps: 6260.21521
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7089.15444
-  tps: 6179.97776
+  dps: 7065.19971
+  tps: 6158.44413
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7089.15444
-  tps: 6179.97776
+  dps: 7065.19971
+  tps: 6158.44413
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7150.347
-  tps: 6237.49963
+  dps: 7151.19392
+  tps: 6237.02094
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7174.28612
-  tps: 6248.97238
+  dps: 7157.36434
+  tps: 6232.78559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6033.80898
-  tps: 5263.97086
+  dps: 6012.59093
+  tps: 5239.45825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7065.40714
-  tps: 6159.22265
+  dps: 7044.43231
+  tps: 6137.68887
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7273.56326
-  tps: 6371.76516
+  dps: 7262.18001
+  tps: 6358.9938
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7088.90711
-  tps: 6179.73043
+  dps: 7064.94744
+  tps: 6158.19186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7890.96887
-  tps: 6966.90655
+  dps: 7871.14226
+  tps: 6948.28921
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8090.70871
-  tps: 7174.15331
+  dps: 8089.53511
+  tps: 7170.91007
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 7343.60691
-  tps: 6425.09019
+  dps: 7326.34916
+  tps: 6407.8235
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14273.45625
-  tps: 14652.2258
+  dps: 14236.55709
+  tps: 14580.70555
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7329.07669
-  tps: 6454.24572
+  dps: 7324.90141
+  tps: 6449.08657
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8331.01675
-  tps: 7309.80794
+  dps: 8330.78712
+  tps: 7306.1445
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7421.54637
-  tps: 8909.49687
+  dps: 7419.48403
+  tps: 8906.3951
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3599.04952
-  tps: 3345.00469
+  dps: 3587.85234
+  tps: 3333.41137
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4183.27324
-  tps: 3849.74406
+  dps: 4195.05272
+  tps: 3861.91515
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14010.41978
-  tps: 14300.56199
+  dps: 14004.61085
+  tps: 14285.5183
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7297.42197
-  tps: 6420.34984
+  dps: 7298.986
+  tps: 6420.80958
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8422.05193
-  tps: 7410.04502
+  dps: 8422.29244
+  tps: 7410.34087
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7270.38337
-  tps: 8731.29153
+  dps: 7276.08147
+  tps: 8736.50395
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3619.6308
-  tps: 3365.42772
+  dps: 3639.9543
+  tps: 3384.9033
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-p1_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4417.04335
-  tps: 4077.45453
+  dps: 4411.11374
+  tps: 4071.71925
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14359.68038
-  tps: 14687.12778
+  dps: 14310.16341
+  tps: 14612.17985
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7336.91871
-  tps: 6411.03702
+  dps: 7321.55788
+  tps: 6395.60841
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8381.62272
-  tps: 7298.11744
+  dps: 8375.51238
+  tps: 7288.85182
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7451.91994
-  tps: 8913.95899
+  dps: 7464.28259
+  tps: 8926.23816
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3613.96817
-  tps: 3340.25507
+  dps: 3616.99977
+  tps: 3343.26479
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4307.38186
-  tps: 3946.3555
+  dps: 4318.7934
+  tps: 3958.84356
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14086.16418
-  tps: 14325.03819
+  dps: 14081.5019
+  tps: 14316.8999
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7332.14873
-  tps: 6407.08953
+  dps: 7335.92033
+  tps: 6408.89376
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8498.64305
-  tps: 7425.75746
+  dps: 8499.04499
+  tps: 7426.36669
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 7323.86233
-  tps: 8769.01204
+  dps: 7315.68111
+  tps: 8761.19336
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3635.79068
-  tps: 3364.35839
+  dps: 3644.65115
+  tps: 3374.87181
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-p1_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4459.92291
-  tps: 4099.34556
+  dps: 4452.83732
+  tps: 4092.51949
  }
 }
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7291.45852
-  tps: 6437.02329
+  dps: 7290.05023
+  tps: 6435.50788
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -46,1103 +46,1103 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 8660.56242
-  tps: 7619.03465
+  dps: 8663.80212
+  tps: 7622.26967
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AshtongueTalismanofSwiftness-32487"
  value: {
-  dps: 7371.81455
-  tps: 6328.77879
+  dps: 7374.71099
+  tps: 6331.99052
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7472.93878
-  tps: 6417.40175
+  dps: 7476.26438
+  tps: 6421.14711
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7496.63554
-  tps: 6447.68204
+  dps: 7499.76306
+  tps: 6451.14304
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7322.06312
-  tps: 6283.26839
+  dps: 7324.96457
+  tps: 6286.47937
   hps: 91.06638
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7322.06312
-  tps: 6283.26839
+  dps: 7324.96457
+  tps: 6286.47937
   hps: 91.06638
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7481.51929
-  tps: 6428.48318
+  dps: 7484.52526
+  tps: 6432.12613
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7442.05071
-  tps: 6403.92794
+  dps: 7443.16613
+  tps: 6405.93074
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBowoftheBetrayer-32336"
  value: {
-  dps: 7193.75512
-  tps: 6155.56198
+  dps: 7195.51812
+  tps: 6157.5886
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 7228.51609
-  tps: 6198.09795
+  dps: 7230.33019
+  tps: 6199.47865
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 7218.0114
-  tps: 6187.9332
+  dps: 7219.82063
+  tps: 6189.30907
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6189.60136
-  tps: 5332.67841
+  dps: 6205.69819
+  tps: 5350.99957
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5937.34261
-  tps: 5097.76301
+  dps: 5918.29263
+  tps: 5082.32248
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6283.79977
+  dps: 7466.67146
+  tps: 6287.46189
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7691.13771
-  tps: 6621.98868
+  dps: 7694.89766
+  tps: 6626.17067
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7694.79381
-  tps: 6624.54149
+  dps: 7698.55504
+  tps: 6628.72533
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7627.42104
-  tps: 6574.43533
+  dps: 7630.67364
+  tps: 6578.31745
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7389.60774
-  tps: 6329.90094
+  dps: 7392.53675
+  tps: 6333.15587
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 6746.24854
-  tps: 5774.78079
+  dps: 6744.37083
+  tps: 5770.83664
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7424.26338
-  tps: 6384.82685
+  dps: 7427.90539
+  tps: 6389.04652
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7469.19039
-  tps: 6429.9056
+  dps: 7472.81483
+  tps: 6434.05135
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7559.40519
-  tps: 6506.01836
+  dps: 7562.136
+  tps: 6509.16948
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7783.15705
-  tps: 6715.24428
+  dps: 7786.51344
+  tps: 6719.03244
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7395.4128
-  tps: 6356.75324
+  dps: 7398.84386
+  tps: 6360.53557
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7674.65063
-  tps: 6620.84821
+  dps: 7677.44221
+  tps: 6623.60742
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7721.72632
-  tps: 6666.71481
+  dps: 7725.58653
+  tps: 6670.53395
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7484.59312
-  tps: 6431.60442
+  dps: 7487.45844
+  tps: 6435.09275
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7384.95177
-  tps: 6359.10651
+  dps: 7386.22946
+  tps: 6359.98533
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7380.93298
-  tps: 6356.24504
+  dps: 7383.12647
+  tps: 6358.4959
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7472.93878
-  tps: 6417.40175
+  dps: 7476.26438
+  tps: 6421.14711
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7470.75659
-  tps: 6417.46993
+  dps: 7474.08347
+  tps: 6421.22496
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7481.51929
-  tps: 6428.53358
+  dps: 7484.52526
+  tps: 6432.16907
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7476.41124
-  tps: 6423.93579
+  dps: 7479.86258
+  tps: 6427.80589
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7350.23249
-  tps: 6320.23424
+  dps: 7351.75105
+  tps: 6322.08438
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7354.41501
-  tps: 6305.46557
+  dps: 7357.33403
+  tps: 6308.70519
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.75405
+  dps: 7466.67146
+  tps: 6414.49474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7480.13764
-  tps: 6440.84623
+  dps: 7484.31566
+  tps: 6445.5791
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7415.51758
-  tps: 6375.97884
+  dps: 7419.70633
+  tps: 6380.73008
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7350.16204
-  tps: 6309.15646
+  dps: 7353.08698
+  tps: 6312.48425
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7392.03069
-  tps: 6353.11523
+  dps: 7395.41272
+  tps: 6357.03248
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.75405
+  dps: 7466.67146
+  tps: 6414.49474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.75405
+  dps: 7466.67146
+  tps: 6414.49474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7514.62771
-  tps: 6458.9109
+  dps: 7517.55511
+  tps: 6462.16114
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 7428.18945
-  tps: 6437.09741
+  dps: 7426.45191
+  tps: 6435.2872
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7444.56361
-  tps: 6405.4303
+  dps: 7448.50058
+  tps: 6409.90966
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gronnstalker'sArmor"
  value: {
-  dps: 5496.56429
-  tps: 4677.2931
+  dps: 5493.64242
+  tps: 4675.69898
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 7722.77793
-  tps: 6656.91927
+  dps: 7726.56506
+  tps: 6661.12668
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 7726.80323
-  tps: 6660.00597
+  dps: 7730.59212
+  tps: 6664.21563
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7321.00201
-  tps: 6282.25827
+  dps: 7323.89762
+  tps: 6285.46944
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7481.51929
-  tps: 6428.53358
+  dps: 7484.52526
+  tps: 6432.16907
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7476.41124
-  tps: 6423.93579
+  dps: 7479.86258
+  tps: 6427.80589
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7470.09763
-  tps: 6423.12905
+  dps: 7473.16739
+  tps: 6426.5184
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7477.86075
-  tps: 6430.54933
+  dps: 7481.19185
+  tps: 6434.40296
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7484.82138
-  tps: 6429.99004
+  dps: 7488.82921
+  tps: 6434.42271
   hps: 12.062
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50179"
  value: {
-  dps: 7673.77123
-  tps: 6609.86283
+  dps: 7677.52513
+  tps: 6614.036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 7670.72448
-  tps: 6607.73549
+  dps: 7674.47732
+  tps: 6611.90711
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 7451.46179
-  tps: 6421.40901
+  dps: 7454.53662
+  tps: 6423.0887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7441.1409
-  tps: 6402.59771
+  dps: 7444.41675
+  tps: 6406.15527
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-49992"
  value: {
-  dps: 7747.796
-  tps: 6677.43971
+  dps: 7751.59614
+  tps: 6681.68271
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Nibelung-50648"
  value: {
-  dps: 7754.66093
-  tps: 6683.42174
+  dps: 7758.46499
+  tps: 6687.66777
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7321.00747
-  tps: 6282.26373
+  dps: 7323.91701
+  tps: 6285.48882
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7484.69621
-  tps: 6430.21185
+  dps: 7488.03138
+  tps: 6433.9662
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7489.7191
-  tps: 6434.79016
+  dps: 7493.05724
+  tps: 6438.54772
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7471.14069
-  tps: 6416.15531
+  dps: 7474.46571
+  tps: 6419.89979
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7472.93878
-  tps: 6417.40175
+  dps: 7476.26438
+  tps: 6421.14711
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7336.40157
-  tps: 6297.49822
+  dps: 7339.19871
+  tps: 6300.59473
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7338.21324
-  tps: 6299.30989
+  dps: 7341.01038
+  tps: 6302.4064
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7642.08503
-  tps: 6587.73848
+  dps: 7645.82789
+  tps: 6591.89554
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.52572
+  dps: 7466.67146
+  tps: 6414.26593
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 7331.98261
-  tps: 6333.65771
+  dps: 7330.50869
+  tps: 6331.86138
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7884.45383
-  tps: 6814.08182
+  dps: 7888.27492
+  tps: 6818.21015
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7389.60774
-  tps: 6329.90094
+  dps: 7392.53675
+  tps: 6333.15587
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7321.01751
-  tps: 6287.7321
+  dps: 7323.92705
+  tps: 6291.01323
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7321.01751
-  tps: 6288.30059
+  dps: 7323.92705
+  tps: 6291.58172
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7417.49432
-  tps: 6379.69412
+  dps: 7421.71251
+  tps: 6384.53068
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 7346.0486
-  tps: 6307.46405
+  dps: 7347.26412
+  tps: 6308.49036
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7420.66959
-  tps: 6372.67818
+  dps: 7423.66331
+  tps: 6375.9929
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StormshroudArmor"
  value: {
-  dps: 5755.9317
-  tps: 4923.74019
+  dps: 5754.46267
+  tps: 4919.40647
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7489.7191
-  tps: 6434.79016
+  dps: 7493.05724
+  tps: 6438.54772
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7484.69621
-  tps: 6430.21185
+  dps: 7488.03138
+  tps: 6433.9662
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7475.90617
-  tps: 6422.19982
+  dps: 7479.23612
+  tps: 6425.94854
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7379.36587
-  tps: 6335.21029
+  dps: 7382.3062
+  tps: 6338.50785
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheFistsofFury"
  value: {
-  dps: 7285.78285
-  tps: 6254.68193
+  dps: 7288.48909
+  tps: 6256.72859
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheTwinBladesofAzzinoth"
  value: {
-  dps: 7426.35573
-  tps: 6394.34881
+  dps: 7428.02749
+  tps: 6395.39609
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7461.7018
-  tps: 6411.5104
+  dps: 7463.85835
+  tps: 6413.40655
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7321.15516
-  tps: 6282.41142
+  dps: 7324.0647
+  tps: 6285.63651
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7321.15516
-  tps: 6282.41142
+  dps: 7324.0647
+  tps: 6285.63651
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.75405
+  dps: 7466.67146
+  tps: 6414.49474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.75405
+  dps: 7466.67146
+  tps: 6414.49474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7355.35097
-  tps: 6323.98346
+  dps: 7358.49203
+  tps: 6326.97317
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.75405
+  dps: 7466.67146
+  tps: 6414.49474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7463.34897
-  tps: 6410.75405
+  dps: 7466.67146
+  tps: 6414.49474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6147.41096
-  tps: 5288.46843
+  dps: 6144.77096
+  tps: 5286.31326
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7302.58734
-  tps: 6272.07829
+  dps: 7303.06364
+  tps: 6272.62774
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 7458.35913
-  tps: 6437.29293
+  dps: 7457.22561
+  tps: 6436.33095
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7321.01751
-  tps: 6282.27377
+  dps: 7323.92705
+  tps: 6285.49887
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 7906.88253
-  tps: 6856.27975
+  dps: 7907.09995
+  tps: 6856.74864
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 8037.25365
-  tps: 6995.72467
+  dps: 8036.87789
+  tps: 6995.38282
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 7612.98595
-  tps: 6565.6601
+  dps: 7613.10031
+  tps: 6565.75152
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31059.93091
-  tps: 31017.00964
+  dps: 29853.6634
+  tps: 29815.90055
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3624.75766
-  tps: 2636.85887
+  dps: 3520.28498
+  tps: 2532.13458
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4884.03696
-  tps: 3722.33325
+  dps: 4883.5329
+  tps: 3691.74871
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12752.98718
-  tps: 13543.01481
+  dps: 12755.7402
+  tps: 13545.70211
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1391.57167
-  tps: 1085.114
+  dps: 1389.15902
+  tps: 1084.83339
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2177.9672
-  tps: 1793.38241
+  dps: 2181.85555
+  tps: 1793.06491
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 19927.45233
-  tps: 20119.42379
+  dps: 19927.14913
+  tps: 20116.05988
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7593.34516
-  tps: 6594.53701
+  dps: 7596.3656
+  tps: 6598.12253
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8453.26375
-  tps: 7322.03316
+  dps: 8463.0163
+  tps: 7332.12918
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10484.3478
-  tps: 11603.73254
+  dps: 10428.59955
+  tps: 11556.10159
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3827.13626
-  tps: 3506.61024
+  dps: 3830.69703
+  tps: 3510.00746
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4559.101
-  tps: 4156.62925
+  dps: 4563.8019
+  tps: 4161.4695
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20149.03802
-  tps: 20319.58535
+  dps: 20148.72403
+  tps: 20315.39194
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7739.69999
-  tps: 6751.73331
+  dps: 7741.21864
+  tps: 6753.20808
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9017.30232
-  tps: 7856.16408
+  dps: 9020.06393
+  tps: 7858.5226
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10466.05932
-  tps: 11547.97439
+  dps: 10474.99021
+  tps: 11553.27142
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3933.31377
-  tps: 3612.25168
+  dps: 3929.57416
+  tps: 3609.33471
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-p1_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4848.84425
-  tps: 4448.7804
+  dps: 4856.07183
+  tps: 4456.42017
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 31043.48583
-  tps: 30943.87507
+  dps: 29860.77239
+  tps: 29774.49725
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 3673.14956
-  tps: 2630.90294
+  dps: 3570.49709
+  tps: 2528.70106
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 4966.71421
-  tps: 3737.25209
+  dps: 4968.93342
+  tps: 3709.33045
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12686.99251
-  tps: 13452.10506
+  dps: 12689.72574
+  tps: 13454.7693
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 1394.86382
-  tps: 1073.72853
+  dps: 1395.18387
+  tps: 1075.54261
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 2204.16822
-  tps: 1798.39967
+  dps: 2210.76598
+  tps: 1800.43601
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20049.17133
-  tps: 20179.21071
+  dps: 20049.5083
+  tps: 20176.45576
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7642.08503
-  tps: 6587.73848
+  dps: 7645.82789
+  tps: 6591.89554
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8517.76595
-  tps: 7319.41841
+  dps: 8527.68736
+  tps: 7329.71529
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10505.88798
-  tps: 11619.96296
+  dps: 10525.40243
+  tps: 11638.77628
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3841.91185
-  tps: 3499.59567
+  dps: 3852.19663
+  tps: 3510.07535
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4597.68871
-  tps: 4171.15978
+  dps: 4604.48689
+  tps: 4178.11404
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20279.19292
-  tps: 20389.06726
+  dps: 20278.06925
+  tps: 20384.31888
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7792.00246
-  tps: 6749.02253
+  dps: 7793.73043
+  tps: 6750.69395
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9099.28167
-  tps: 7869.87002
+  dps: 9101.88227
+  tps: 7872.08186
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10507.53265
-  tps: 11565.82034
+  dps: 10523.87074
+  tps: 11584.14181
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3958.60189
-  tps: 3618.87902
+  dps: 3957.79956
+  tps: 3617.21571
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-p1_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4895.3864
-  tps: 4471.19964
+  dps: 4902.7106
+  tps: 4479.00073
  }
 }
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7549.34654
-  tps: 6580.41491
+  dps: 7546.32952
+  tps: 6577.29598
  }
 }

--- a/sim/hunter/pet.go
+++ b/sim/hunter/pet.go
@@ -92,7 +92,7 @@ func (hp *HunterPet) Reset(_ *core.Simulation) {
 	hp.uptimePercent = min(1, max(0, hp.hunterOwner.Options.PetUptime))
 }
 
-func (hp *HunterPet) OnGCDReady(sim *core.Simulation) {
+func (hp *HunterPet) ExecuteCustomRotation(sim *core.Simulation) {
 	percentRemaining := sim.GetRemainingDurationPercent()
 	if percentRemaining < 1.0-hp.uptimePercent { // once fight is % completed, disable pet.
 		hp.Disable(sim)
@@ -102,7 +102,6 @@ func (hp *HunterPet) OnGCDReady(sim *core.Simulation) {
 	if hp.hasOwnerCooldown && hp.CurrentFocus() < 50 {
 		// When a major ability (Furious Howl or Savage Rend) is ready, pool enough
 		// energy to use on-demand.
-		hp.DoNothing()
 		return
 	}
 
@@ -111,13 +110,13 @@ func (hp *HunterPet) OnGCDReady(sim *core.Simulation) {
 		if sim.RandomFloat("Hunter Pet Ability") < 0.5 {
 			if !hp.specialAbility.CanCast(sim, target) || !hp.specialAbility.Cast(sim, target) {
 				if !hp.focusDump.Cast(sim, target) {
-					hp.DoNothing()
+					// Do nothing
 				}
 			}
 		} else {
 			if !hp.focusDump.Cast(sim, target) {
 				if !hp.specialAbility.CanCast(sim, target) || !hp.specialAbility.Cast(sim, target) {
-					hp.DoNothing()
+					// Do nothing
 				}
 			}
 		}
@@ -129,19 +128,19 @@ func (hp *HunterPet) OnGCDReady(sim *core.Simulation) {
 		if hp.GCD.IsReady(sim) {
 			if hp.focusDump != nil {
 				if !hp.focusDump.Cast(sim, target) {
-					hp.DoNothing()
+					// Do nothing
 				}
 			} else {
-				hp.DoNothing()
+				// Do nothing
 			}
 		}
 	} else {
 		if hp.focusDump != nil {
 			if !hp.focusDump.Cast(sim, target) {
-				hp.DoNothing()
+				// Do nothing
 			}
 		} else {
-			hp.DoNothing()
+			// Do nothing
 		}
 	}
 }

--- a/sim/mage/mirror_image.go
+++ b/sim/mage/mirror_image.go
@@ -91,7 +91,7 @@ func (mi *MirrorImage) Initialize() {
 func (mi *MirrorImage) Reset(_ *core.Simulation) {
 }
 
-func (mi *MirrorImage) OnGCDReady(sim *core.Simulation) {
+func (mi *MirrorImage) ExecuteCustomRotation(sim *core.Simulation) {
 	spell := mi.Frostbolt
 	if mi.Fireblast.CD.IsReady(sim) && sim.RandomFloat("MirrorImage FB") < 0.5 {
 		spell = mi.Fireblast

--- a/sim/mage/water_elemental.go
+++ b/sim/mage/water_elemental.go
@@ -87,7 +87,7 @@ func (we *WaterElemental) Initialize() {
 func (we *WaterElemental) Reset(_ *core.Simulation) {
 }
 
-func (we *WaterElemental) OnGCDReady(sim *core.Simulation) {
+func (we *WaterElemental) ExecuteCustomRotation(sim *core.Simulation) {
 	spell := we.Waterbolt
 
 	if sim.RandomFloat("Water Elemental Disobey") < we.disobeyChance {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -47,42 +47,42 @@ dps_results: {
  key: "TestShadow-AllItems-AbsolutionRegalia"
  value: {
   dps: 5198.67673
-  tps: 5035.86332
+  tps: 5035.33834
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50359"
  value: {
   dps: 7241.85687
-  tps: 7040.23265
+  tps: 7039.71287
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
   dps: 7278.58399
-  tps: 7075.79278
+  tps: 7075.27299
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50354"
  value: {
   dps: 6944.54538
-  tps: 6752.1336
+  tps: 6751.61382
   hps: 88.41863
  }
 }
@@ -90,7 +90,7 @@ dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
   dps: 6944.54538
-  tps: 6752.1336
+  tps: 6751.61382
   hps: 88.41863
  }
 }
@@ -98,49 +98,49 @@ dps_results: {
  key: "TestShadow-AllItems-BeamingEarthsiegeDiamond"
  value: {
   dps: 7125.97107
-  tps: 6925.45188
+  tps: 6924.97253
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
   dps: 5973.02741
-  tps: 5795.17183
+  tps: 5794.81693
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 7138.25812
-  tps: 6798.53896
+  tps: 6798.04287
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50352"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
   hps: 64
  }
 }
@@ -148,686 +148,686 @@ dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
   dps: 7513.5628
-  tps: 7289.0078
+  tps: 7288.93035
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
   dps: 8683.83654
-  tps: 8483.38921
+  tps: 8482.73654
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 7064.85671
-  tps: 6872.6719
+  tps: 6872.16199
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Death-42990"
  value: {
   dps: 7127.74083
-  tps: 6935.85616
+  tps: 6935.41914
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
   dps: 7040.1315
-  tps: 6858.159
+  tps: 6857.68758
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DeathKnight'sAnguish-38212"
  value: {
   dps: 6978.37553
-  tps: 6786.27015
+  tps: 6785.7358
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
   dps: 7130.42738
-  tps: 6930.10414
+  tps: 6929.58436
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
   dps: 7679.33557
-  tps: 7478.88905
+  tps: 7478.40948
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
   dps: 7597.07623
-  tps: 7399.15862
+  tps: 7398.37638
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 7143.55661
-  tps: 6941.54711
+  tps: 6941.07072
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
   dps: 7125.97107
-  tps: 6925.64783
+  tps: 6925.12805
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 7121.34694
-  tps: 6920.99373
+  tps: 6920.48231
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
   dps: 7108.93633
-  tps: 6920.69544
+  tps: 6919.95322
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceofGossamer-37220"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 7130.37674
-  tps: 6939.2637
+  tps: 6938.85926
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 7275.73784
-  tps: 7076.98154
+  tps: 7076.46188
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-SapphireOwl-42413"
  value: {
   dps: 6959.61553
-  tps: 6766.8679
+  tps: 6766.38813
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForethoughtTalisman-40258"
  value: {
   dps: 7128.33669
-  tps: 6930.31954
+  tps: 6929.79975
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
   dps: 7038.01449
-  tps: 6845.79893
+  tps: 6845.29232
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
   dps: 7138.25812
-  tps: 6936.54032
+  tps: 6936.04422
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 7130.10161
-  tps: 6928.64902
+  tps: 6928.15293
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
   dps: 7085.88858
-  tps: 6886.82957
+  tps: 6886.39962
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
   dps: 6350.10719
-  tps: 6161.89618
+  tps: 6161.57562
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
   dps: 6787.23006
-  tps: 6562.33781
+  tps: 6562.19387
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
   dps: 6910.53551
-  tps: 6702.31462
+  tps: 6701.93398
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
   dps: 7260.22043
-  tps: 7058.01271
+  tps: 7057.49293
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
   dps: 7301.95579
-  tps: 7098.42195
+  tps: 7097.90217
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
   dps: 7092.14299
-  tps: 6900.62669
+  tps: 6900.19226
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
   dps: 7125.97107
-  tps: 6925.64783
+  tps: 6925.12805
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 7121.34694
-  tps: 6920.99373
+  tps: 6920.48231
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 7107.10834
-  tps: 6912.19724
+  tps: 6911.93157
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 7112.93278
-  tps: 6914.09716
+  tps: 6913.75285
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 7039.8608
-  tps: 6847.64523
+  tps: 6847.13862
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NevermeltingIceCrystal-50259"
  value: {
   dps: 7229.4413
-  tps: 7030.90145
+  tps: 7030.399
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-49992"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Nibelung-50648"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54571"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
   dps: 6152.58189
-  tps: 5959.11632
+  tps: 5958.75917
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47316"
  value: {
   dps: 7359.24135
-  tps: 7160.96345
+  tps: 7160.5395
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
   dps: 7409.64675
-  tps: 7210.4236
+  tps: 7209.99965
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 7233.96602
-  tps: 7033.57434
+  tps: 7033.07825
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
   dps: 7097.47554
-  tps: 6896.51651
+  tps: 6896.03649
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
   dps: 6910.4836
-  tps: 6716.24047
+  tps: 6715.81873
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
   dps: 6599.798
-  tps: 6401.22733
+  tps: 6400.95497
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShinyShardoftheGods"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50339"
  value: {
   dps: 7206.79916
-  tps: 7008.99723
+  tps: 7008.714
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
   dps: 7240.18745
-  tps: 7041.66715
+  tps: 7041.49526
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulPreserver-37111"
  value: {
   dps: 7068.23776
-  tps: 6872.13024
+  tps: 6871.61046
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
   dps: 7062.39266
-  tps: 6870.15394
+  tps: 6869.6342
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SparkofLife-37657"
  value: {
   dps: 7080.90281
-  tps: 6886.08731
+  tps: 6885.87205
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
   dps: 6954.04983
-  tps: 6761.82744
+  tps: 6761.39095
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
   dps: 7012.24458
-  tps: 6817.42394
+  tps: 6816.9399
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
   dps: 6971.21223
-  tps: 6777.86938
+  tps: 6777.39049
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheGeneral'sHeart-45507"
  value: {
   dps: 6943.03168
-  tps: 6750.90254
+  tps: 6750.38276
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
   dps: 7097.47554
-  tps: 6897.08386
+  tps: 6896.58776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 6954.04983
-  tps: 6761.82744
+  tps: 6761.39095
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 6954.04983
-  tps: 6761.82744
+  tps: 6761.39095
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
   dps: 7138.25812
-  tps: 6936.54032
+  tps: 6936.04422
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 7130.10161
-  tps: 6928.64902
+  tps: 6928.15293
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
   dps: 7163.48958
-  tps: 6969.76802
+  tps: 6969.34016
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 7130.10161
-  tps: 6928.64902
+  tps: 6928.15293
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
   dps: 7138.25812
-  tps: 6936.54032
+  tps: 6936.04422
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 7558.82137
-  tps: 7355.50129
+  tps: 7354.73286
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
   dps: 5075.14844
-  tps: 4909.7768
+  tps: 4909.21293
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
   dps: 7076.51323
-  tps: 6874.68839
+  tps: 6874.16861
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
   dps: 6508.31094
-  tps: 6311.17597
+  tps: 6310.96351
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
   dps: 6858.65338
-  tps: 6659.66128
+  tps: 6659.22253
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
   dps: 7332.47719
-  tps: 7131.73958
+  tps: 7131.2575
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7273.89542
-  tps: 7760.88225
+  tps: 7752.16096
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7273.89542
-  tps: 7073.57218
+  tps: 7073.13611
  }
 }
 dps_results: {
@@ -862,14 +862,14 @@ dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7273.89542
-  tps: 7760.88225
+  tps: 7752.16096
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7273.89542
-  tps: 7073.57218
+  tps: 7073.13611
  }
 }
 dps_results: {
@@ -904,14 +904,14 @@ dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7273.89542
-  tps: 7760.88225
+  tps: 7752.16096
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7273.89542
-  tps: 7073.57218
+  tps: 7073.13611
  }
 }
 dps_results: {
@@ -946,14 +946,14 @@ dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7260.45977
-  tps: 7756.20974
+  tps: 7745.78039
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7260.45977
-  tps: 7060.29154
+  tps: 7059.77007
  }
 }
 dps_results: {
@@ -988,14 +988,14 @@ dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7260.45977
-  tps: 7756.20974
+  tps: 7745.78039
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7260.45977
-  tps: 7060.29154
+  tps: 7059.77007
  }
 }
 dps_results: {
@@ -1030,14 +1030,14 @@ dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7260.45977
-  tps: 7756.20974
+  tps: 7745.78039
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7260.45977
-  tps: 7060.29154
+  tps: 7059.77007
  }
 }
 dps_results: {
@@ -1072,14 +1072,14 @@ dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7264.9512
-  tps: 7759.18184
+  tps: 7748.78619
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
@@ -1114,14 +1114,14 @@ dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7264.9512
-  tps: 7759.18184
+  tps: 7748.78619
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Clipping-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
@@ -1156,14 +1156,14 @@ dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-FullBuffs-LongMultiTarget"
  value: {
   dps: 7264.9512
-  tps: 7759.18184
+  tps: 7748.78619
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Undead-p1-Ideal-default-FullBuffs-LongSingleTarget"
  value: {
   dps: 7264.9512
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }
 dps_results: {
@@ -1198,6 +1198,6 @@ dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
   dps: 7267.49487
-  tps: 7064.62796
+  tps: 7064.10818
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -49,12 +49,12 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.27696
+  weights: 4.52675
   weights: 0
-  weights: 1.61352
+  weights: 1.60973
   weights: 0
   weights: 0
-  weights: 1.54675
+  weights: 1.43945
   weights: 0
   weights: 0
   weights: 0
@@ -91,1281 +91,1281 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 6881.15334
-  tps: 3846.1353
+  dps: 6863.28823
+  tps: 3844.36465
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 6914.79694
-  tps: 3864.83817
+  dps: 6896.84001
+  tps: 3863.05201
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7068.1251
-  tps: 3920.70146
+  dps: 7073.31686
+  tps: 3931.20584
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 6646.61452
-  tps: 3675.87435
+  dps: 6637.19889
+  tps: 3686.64787
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7002.92509
-  tps: 3877.4109
+  dps: 6957.45214
+  tps: 3860.74595
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50035"
  value: {
-  dps: 5943.73698
-  tps: 3287.10074
+  dps: 5934.84303
+  tps: 3289.58182
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 5943.73698
-  tps: 3287.10074
+  dps: 5934.84303
+  tps: 3289.58182
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 4836.37311
-  tps: 2644.46541
+  dps: 4849.76749
+  tps: 2661.84341
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 5108.73411
-  tps: 2798.06356
+  dps: 5087.30576
+  tps: 2788.85887
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 6976.23329
-  tps: 3786.55767
+  dps: 7008.89733
+  tps: 3813.18697
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 6796.07951
-  tps: 3808.38876
+  dps: 6732.02618
+  tps: 3773.01076
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 6789.02315
-  tps: 3816.38505
+  dps: 6860.7293
+  tps: 3880.09818
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7057.85811
-  tps: 3961.19749
+  dps: 7040.20523
+  tps: 3959.90556
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7078.804
-  tps: 3924.65639
+  dps: 7105.93371
+  tps: 3949.85562
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 6648.40171
-  tps: 3717.34793
+  dps: 6654.44856
+  tps: 3731.08418
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 6543.38088
-  tps: 3649.77568
+  dps: 6608.92553
+  tps: 3701.80012
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 6613.98632
-  tps: 3693.13994
+  dps: 6615.30831
+  tps: 3701.43181
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 6960.64024
-  tps: 3853.90887
+  dps: 6983.31752
+  tps: 3875.81743
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7013.41374
-  tps: 3923.18074
+  dps: 6965.38963
+  tps: 3900.5792
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 6971.55004
-  tps: 3903.16493
+  dps: 6941.53415
+  tps: 3893.17893
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 5292.02484
-  tps: 2896.4247
+  dps: 5240.68746
+  tps: 2874.25887
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EarthshatterGarb"
  value: {
-  dps: 6664.36625
-  tps: 3701.51496
+  dps: 6674.94094
+  tps: 3717.32881
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7073.06389
-  tps: 3920.80951
+  dps: 7109.25352
+  tps: 3952.04187
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 6955.80244
-  tps: 3851.36251
+  dps: 6981.25486
+  tps: 3875.42442
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 6954.03438
-  tps: 3850.65213
+  dps: 6978.29223
+  tps: 3873.56016
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 6856.93051
-  tps: 3863.27719
+  dps: 6796.89239
+  tps: 3823.35342
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 6968.95152
-  tps: 3903.67704
+  dps: 6921.47785
+  tps: 3875.31782
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 6794.68363
-  tps: 3812.37487
+  dps: 6752.7015
+  tps: 3787.08978
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 6777.16402
-  tps: 3788.32645
+  dps: 6759.58274
+  tps: 3786.60372
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 6875.40371
-  tps: 3838.45911
+  dps: 6857.94549
+  tps: 3833.97125
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 6976.23329
-  tps: 3863.63504
+  dps: 7008.89733
+  tps: 3890.80376
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 6968.50208
-  tps: 3859.35382
+  dps: 7001.13056
+  tps: 3886.493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 6262.50574
-  tps: 3476.47836
+  dps: 6251.22911
+  tps: 3478.8872
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 8215.41125
-  tps: 4564.44786
+  dps: 8181.04054
+  tps: 4550.42527
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7093.21523
-  tps: 3932.48492
+  dps: 7120.43152
+  tps: 3957.75317
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 6702.23054
-  tps: 3746.67007
+  dps: 6684.85377
+  tps: 3744.98187
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 5648.8804
-  tps: 3149.2505
+  dps: 5674.43948
+  tps: 3169.07236
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6472.09266
-  tps: 3583.75904
+  dps: 6486.91113
+  tps: 3600.91125
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 6897.97514
-  tps: 3855.48674
+  dps: 6880.06412
+  tps: 3853.70833
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 6936.2065
-  tps: 3876.73999
+  dps: 6918.19114
+  tps: 3874.94396
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 6764.79386
-  tps: 3790.526
+  dps: 6720.43279
+  tps: 3765.32555
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7041.97254
-  tps: 3904.12476
+  dps: 7068.6805
+  tps: 3929.02562
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 6955.80244
-  tps: 3851.36251
+  dps: 6981.25486
+  tps: 3875.42442
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 6954.03438
-  tps: 3850.65213
+  dps: 6978.29223
+  tps: 3873.56016
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7280.84768
-  tps: 4052.67289
+  dps: 7290.49152
+  tps: 4066.63225
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 6715.19854
-  tps: 3760.06958
+  dps: 6703.01641
+  tps: 3757.5639
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 6777.16402
-  tps: 3788.32645
+  dps: 6759.58274
+  tps: 3786.60372
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-49992"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Nibelung-50648"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7061.46289
-  tps: 4036.9254
+  dps: 7052.24444
+  tps: 4039.06046
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7112.4668
-  tps: 4075.66675
+  dps: 7103.52117
+  tps: 4078.12459
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7117.50792
-  tps: 3953.8092
+  dps: 7152.70434
+  tps: 3982.54241
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7110.71459
-  tps: 3941.991
+  dps: 7138.036
+  tps: 3967.34306
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7033.23622
-  tps: 3896.95902
+  dps: 7046.129
+  tps: 3916.29081
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7036.29113
-  tps: 3901.12297
+  dps: 7062.9973
+  tps: 3926.0163
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7053.28384
-  tps: 3911.36591
+  dps: 6996.67757
+  tps: 3883.18757
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 4246.50487
-  tps: 2314.02659
+  dps: 4242.77008
+  tps: 2309.658
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5227.96327
-  tps: 2869.59107
+  dps: 5207.79808
+  tps: 2868.59121
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 6849.03899
-  tps: 3828.28257
+  dps: 6831.26153
+  tps: 3826.52671
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 6879.62408
-  tps: 3845.28517
+  dps: 6861.76315
+  tps: 3843.51522
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 6722.11085
-  tps: 3757.72176
+  dps: 6704.67982
+  tps: 3756.0244
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7100.21595
-  tps: 3997.10518
+  dps: 7069.54719
+  tps: 3985.56698
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 6905.2944
-  tps: 3880.89193
+  dps: 7025.73924
+  tps: 3971.04629
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 6850.88061
-  tps: 3830.72422
+  dps: 6837.78129
+  tps: 3823.43591
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7006.74782
-  tps: 3885.5137
+  dps: 7033.44467
+  tps: 3910.36784
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 4686.54261
-  tps: 2553.20342
+  dps: 4709.32376
+  tps: 2574.18851
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 6958.21337
-  tps: 3902.88762
+  dps: 6909.61723
+  tps: 3881.54719
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheFistsofFury"
  value: {
-  dps: 5937.55444
-  tps: 3264.806
+  dps: 5891.32972
+  tps: 3249.59732
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 5815.19818
-  tps: 3227.11897
+  dps: 5796.83651
+  tps: 3216.81418
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6940.60135
-  tps: 3883.87524
+  dps: 6929.19955
+  tps: 3885.68471
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 6937.57725
-  tps: 3842.22896
+  dps: 6970.06348
+  tps: 3869.24998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 4753.91135
-  tps: 2594.97924
+  dps: 4718.56457
+  tps: 2574.31116
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 6910.87608
-  tps: 3860.71691
+  dps: 6988.22174
+  tps: 3926.40867
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 6910.87608
-  tps: 3860.71691
+  dps: 6988.22174
+  tps: 3926.40867
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 6976.23329
-  tps: 3863.63504
+  dps: 7008.89733
+  tps: 3890.80376
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 6968.50208
-  tps: 3859.35382
+  dps: 7001.13056
+  tps: 3886.493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 6711.40607
-  tps: 3751.77085
+  dps: 6694.00426
+  tps: 3750.07842
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 6998.87138
-  tps: 3876.89372
+  dps: 6976.71388
+  tps: 3877.7192
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7006.74782
-  tps: 3885.5137
+  dps: 7033.44467
+  tps: 3910.36784
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7006.74782
-  tps: 3885.5137
+  dps: 7033.44467
+  tps: 3910.36784
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7009.45701
-  tps: 3886.51357
+  dps: 7016.26152
+  tps: 3891.61216
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 6968.50208
-  tps: 3859.35382
+  dps: 7001.13056
+  tps: 3886.493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 6976.23329
-  tps: 3863.63504
+  dps: 7008.89733
+  tps: 3890.80376
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 4591.16783
-  tps: 2495.53648
+  dps: 4569.19693
+  tps: 2487.70946
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7393.38306
-  tps: 4106.02221
+  dps: 7395.35643
+  tps: 4118.76991
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 6607.41676
-  tps: 3693.962
+  dps: 6590.29876
+  tps: 3692.31749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 5393.71814
-  tps: 2961.72666
+  dps: 5369.52365
+  tps: 2952.12673
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WorldbreakerGarb"
  value: {
-  dps: 7016.15742
-  tps: 3960.93878
+  dps: 6993.19748
+  tps: 3958.54516
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7129.24332
-  tps: 3952.05626
+  dps: 7156.67604
+  tps: 3977.49706
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 7287.96077
-  tps: 4039.44759
+  dps: 7276.45932
+  tps: 4041.15477
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9840.69885
-  tps: 4752.84315
+  dps: 9771.21018
+  tps: 4705.22913
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7458.6682
-  tps: 4125.47809
+  dps: 7454.50067
+  tps: 4140.478
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8955.74736
-  tps: 4674.30922
+  dps: 8964.30154
+  tps: 4708.79854
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5624.96049
-  tps: 2381.13178
+  dps: 5521.03184
+  tps: 2325.24307
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3878.88818
-  tps: 2052.11172
+  dps: 3837.05884
+  tps: 2026.4407
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6509.36129
-  tps: 3357.28864
+  dps: 6515.97761
+  tps: 3373.88626
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8555.86373
-  tps: 3762.04464
+  dps: 8579.99908
+  tps: 3796.63806
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7315.61572
-  tps: 4046.52294
+  dps: 7313.94007
+  tps: 4056.90464
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9440.83551
-  tps: 4975.43993
+  dps: 9410.66293
+  tps: 4967.07992
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4816.70456
-  tps: 1635.4101
+  dps: 4748.6775
+  tps: 1590.44032
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3299.1706
-  tps: 1680.77368
+  dps: 3294.32029
+  tps: 1688.70458
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Adaptive-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6649.15379
-  tps: 3431.25339
+  dps: 6610.40307
+  tps: 3428.92065
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9840.69885
-  tps: 4752.84315
+  dps: 9771.21018
+  tps: 4705.22913
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7458.6682
-  tps: 4125.47809
+  dps: 7454.50067
+  tps: 4140.478
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8955.74736
-  tps: 4674.30922
+  dps: 8964.30154
+  tps: 4708.79854
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5624.96049
-  tps: 2381.13178
+  dps: 5521.03184
+  tps: 2325.24307
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3878.88818
-  tps: 2052.11172
+  dps: 3837.05884
+  tps: 2026.4407
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6509.36129
-  tps: 3357.28864
+  dps: 6515.97761
+  tps: 3373.88626
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8555.86373
-  tps: 3762.04464
+  dps: 8579.99908
+  tps: 3796.63806
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7315.61572
-  tps: 4046.52294
+  dps: 7313.94007
+  tps: 4056.90464
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9440.83551
-  tps: 4975.43993
+  dps: 9410.66293
+  tps: 4967.07992
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4816.70456
-  tps: 1635.4101
+  dps: 4748.6775
+  tps: 1590.44032
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3299.1706
-  tps: 1680.77368
+  dps: 3294.32029
+  tps: 1688.70458
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-EleFireElemental-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6649.15379
-  tps: 3431.25339
+  dps: 6610.40307
+  tps: 3428.92065
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9546.15132
-  tps: 4680.47017
+  dps: 9488.36304
+  tps: 4655.75987
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7396.36835
-  tps: 4126.68301
+  dps: 7367.11741
+  tps: 4114.77864
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9159.66165
-  tps: 4943.86712
+  dps: 9035.33243
+  tps: 4858.19017
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5462.52243
-  tps: 2391.51442
+  dps: 5368.23343
+  tps: 2330.5972
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3805.33866
-  tps: 2029.18744
+  dps: 3821.62337
+  tps: 2048.21029
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6557.0291
-  tps: 3454.07046
+  dps: 6522.405
+  tps: 3434.46393
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8299.65462
-  tps: 3714.57623
+  dps: 8332.51565
+  tps: 3761.82317
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9079.01752
-  tps: 4799.59458
+  dps: 9014.56519
+  tps: 4792.02486
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4595.86571
-  tps: 1593.89678
+  dps: 4640.63962
+  tps: 1619.5725
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3247.20579
-  tps: 1665.69907
+  dps: 3256.28858
+  tps: 1685.78523
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Adaptive-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6445.15877
-  tps: 3333.06464
+  dps: 6403.21606
+  tps: 3333.61161
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 9546.15132
-  tps: 4680.47017
+  dps: 9488.36304
+  tps: 4655.75987
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7396.36835
-  tps: 4126.68301
+  dps: 7367.11741
+  tps: 4114.77864
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9159.66165
-  tps: 4943.86712
+  dps: 9035.33243
+  tps: 4858.19017
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5462.52243
-  tps: 2391.51442
+  dps: 5368.23343
+  tps: 2330.5972
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3805.33866
-  tps: 2029.18744
+  dps: 3821.62337
+  tps: 2048.21029
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6557.0291
-  tps: 3454.07046
+  dps: 6522.405
+  tps: 3434.46393
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8299.65462
-  tps: 3714.57623
+  dps: 8332.51565
+  tps: 3761.82317
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7137.05992
-  tps: 3963.61594
+  dps: 7164.80442
+  tps: 3989.22636
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9079.01752
-  tps: 4799.59458
+  dps: 9014.56519
+  tps: 4792.02486
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4595.86571
-  tps: 1593.89678
+  dps: 4640.63962
+  tps: 1619.5725
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3247.20579
-  tps: 1665.69907
+  dps: 3256.28858
+  tps: 1685.78523
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-EleFireElemental-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6445.15877
-  tps: 3333.06464
+  dps: 6403.21606
+  tps: 3333.61161
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7115.06773
-  tps: 3963.61594
+  dps: 7144.09519
+  tps: 3989.22636
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -46,1453 +46,1453 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 7553.24029
-  tps: 4507.81263
+  dps: 7495.27202
+  tps: 4476.32401
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7573.35045
-  tps: 4519.41546
+  dps: 7515.25781
+  tps: 4487.87648
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 7435.99639
-  tps: 4447.25146
+  dps: 7453.27251
+  tps: 4466.80071
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 7557.02977
-  tps: 4520.87412
+  dps: 7554.84156
+  tps: 4526.09426
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 7389.75182
-  tps: 4413.48437
-  hps: 95.40076
+  dps: 7332.11798
+  tps: 4381.92469
+  hps: 95.31154
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7389.75182
-  tps: 4413.48437
-  hps: 95.40076
+  dps: 7332.11798
+  tps: 4381.92469
+  hps: 95.31154
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 7432.35877
-  tps: 4442.81408
+  dps: 7475.4372
+  tps: 4478.1474
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 7218.14333
-  tps: 4289.60815
+  dps: 7232.02539
+  tps: 4313.87788
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 7856.64321
-  tps: 4732.80755
+  dps: 7855.50298
+  tps: 4740.72426
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 7434.92491
-  tps: 4494.63953
+  dps: 7412.5882
+  tps: 4489.74813
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 7494.70501
-  tps: 4538.95119
+  dps: 7470.72852
+  tps: 4532.44917
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 6109.18551
-  tps: 3607.67788
+  dps: 6084.25769
+  tps: 3597.2036
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 6030.38856
-  tps: 3541.23197
+  dps: 6042.72509
+  tps: 3571.71604
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 7459.00644
-  tps: 4374.04041
+  dps: 7476.2745
+  tps: 4393.24997
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 7603.17967
-  tps: 4555.65483
+  dps: 7647.17497
+  tps: 4592.67854
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 7389.61825
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 7518.5092
-  tps: 4498.27222
+  dps: 7483.48088
+  tps: 4487.98327
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 7501.87551
-  tps: 4495.6656
+  dps: 7540.4839
+  tps: 4527.86024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 7583.68837
-  tps: 4533.38005
+  dps: 7570.47222
+  tps: 4529.64648
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 7641.81007
-  tps: 4575.75637
+  dps: 7609.40637
+  tps: 4564.21965
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 7754.03483
-  tps: 4635.5988
+  dps: 7750.15371
+  tps: 4643.09984
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 7478.81783
-  tps: 4474.89391
+  dps: 7440.95352
+  tps: 4453.82666
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 7713.11606
-  tps: 4609.82013
+  dps: 7686.47447
+  tps: 4601.87058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7761.25763
-  tps: 4635.01714
+  dps: 7727.54852
+  tps: 4619.2286
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 7389.61825
-  tps: 4413.40777
+  dps: 7332.65376
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 7451.67349
-  tps: 4455.85297
+  dps: 7486.82923
+  tps: 4488.01555
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7838.56885
-  tps: 4698.90881
+  dps: 7839.07384
+  tps: 4703.53131
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 7737.22557
-  tps: 4629.76162
+  dps: 7794.1279
+  tps: 4676.09643
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 6830.1101
-  tps: 4047.32905
+  dps: 6772.67477
+  tps: 4020.22123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EarthshatterGarb"
  value: {
-  dps: 6481.4933
-  tps: 3798.53104
+  dps: 6442.57822
+  tps: 3778.89534
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 7435.99639
-  tps: 4447.25146
+  dps: 7453.27251
+  tps: 4466.80071
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 7484.73312
-  tps: 4481.03352
+  dps: 7495.68848
+  tps: 4491.29636
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 7448.96862
-  tps: 4454.26339
+  dps: 7489.61164
+  tps: 4488.85262
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 7444.78617
-  tps: 4452.11254
+  dps: 7483.70204
+  tps: 4484.90953
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 7499.52308
-  tps: 4486.02841
+  dps: 7491.91952
+  tps: 4488.83278
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 7435.99639
-  tps: 4447.25146
+  dps: 7453.27251
+  tps: 4466.80071
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 7515.8872
-  tps: 4500.42451
+  dps: 7526.77292
+  tps: 4511.50235
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 7630.83125
-  tps: 4563.4738
+  dps: 7574.35318
+  tps: 4534.18263
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 7405.94361
-  tps: 4421.57844
+  dps: 7416.08352
+  tps: 4431.4224
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 7491.08158
-  tps: 4471.94933
+  dps: 7433.49777
+  tps: 4440.61636
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 7568.8856
-  tps: 4508.5212
+  dps: 7515.59234
+  tps: 4485.04989
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 7459.00644
-  tps: 4460.53363
+  dps: 7476.2745
+  tps: 4480.1253
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 7454.40443
-  tps: 4457.8772
+  dps: 7471.6741
+  tps: 4477.46039
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 8357.1926
-  tps: 5002.20147
+  dps: 8292.52088
+  tps: 4959.92374
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 7884.09459
-  tps: 4676.48748
+  dps: 7858.76112
+  tps: 4667.01552
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 7654.7543
-  tps: 4583.22708
+  dps: 7622.29137
+  tps: 4571.6883
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 7596.04965
-  tps: 4541.75277
+  dps: 7546.25414
+  tps: 4514.76307
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 7446.2937
-  tps: 4446.10666
+  dps: 7388.98
+  tps: 4414.88585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 7080.89487
-  tps: 4181.35909
+  dps: 7082.25079
+  tps: 4196.02949
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gladiator'sWartide"
  value: {
-  dps: 6237.8568
-  tps: 3612.26821
+  dps: 6236.13095
+  tps: 3622.32853
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 7563.29831
-  tps: 4513.61405
+  dps: 7505.26094
+  tps: 4482.10025
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7586.15078
-  tps: 4526.79908
+  dps: 7527.97206
+  tps: 4495.22806
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 7529.80769
-  tps: 4505.82394
+  dps: 7525.24542
+  tps: 4515.91103
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 7617.13086
-  tps: 4560.72905
+  dps: 7585.43584
+  tps: 4549.42937
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 7560.01024
-  tps: 4514.67166
+  dps: 7502.05326
+  tps: 4483.13383
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 7448.96862
-  tps: 4454.26339
+  dps: 7489.61164
+  tps: 4488.85262
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 7444.78617
-  tps: 4452.11254
+  dps: 7483.70204
+  tps: 4484.90953
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 7522.52703
-  tps: 4500.89073
+  dps: 7472.12359
+  tps: 4471.46999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 7446.13527
-  tps: 4450.81634
+  dps: 7476.62922
+  tps: 4475.72159
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 7472.51919
-  tps: 4470.10948
+  dps: 7479.45077
+  tps: 4483.27645
   hps: 11.01615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 7389.61825
-  tps: 4413.40777
+  dps: 7332.65376
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 7511.2523
-  tps: 4486.09788
+  dps: 7462.16341
+  tps: 4460.69184
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-49992"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Nibelung-50648"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 7389.61985
-  tps: 4413.40777
+  dps: 7332.65376
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 7466.81249
-  tps: 4466.58156
+  dps: 7475.50123
+  tps: 4480.46371
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 7472.51919
-  tps: 4470.10948
+  dps: 7479.45077
+  tps: 4483.27645
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 7389.61089
-  tps: 4413.40777
+  dps: 7332.66333
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 7435.99639
-  tps: 4447.25146
+  dps: 7453.27251
+  tps: 4466.80071
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 7435.99639
-  tps: 4447.25146
+  dps: 7453.27251
+  tps: 4466.80071
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 7804.74273
-  tps: 4692.0187
+  dps: 7755.29425
+  tps: 4660.18764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 7855.2909
-  tps: 4725.38883
+  dps: 7805.94948
+  tps: 4693.64181
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 7670.47229
-  tps: 4592.29865
+  dps: 7637.93745
+  tps: 4580.75736
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 7446.98825
-  tps: 4457.16833
+  dps: 7438.17341
+  tps: 4452.50166
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 7389.61825
-  tps: 4413.40777
+  dps: 7332.65376
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 7610.67248
-  tps: 4557.12805
+  dps: 7578.90986
+  tps: 4545.7918
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 7389.61825
-  tps: 4413.40777
+  dps: 7332.65376
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66304
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 7592.513
-  tps: 4546.56603
+  dps: 7544.52658
+  tps: 4528.58867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 5431.336
-  tps: 3160.02758
+  dps: 5486.12958
+  tps: 3196.75812
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 5392.90081
-  tps: 3118.73339
+  dps: 5357.19253
+  tps: 3094.9146
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 7512.85133
-  tps: 4488.84558
+  dps: 7517.962
+  tps: 4495.16946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 7521.18286
-  tps: 4489.52128
+  dps: 7533.63331
+  tps: 4507.02618
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 7458.17403
-  tps: 4452.96288
+  dps: 7400.79375
+  tps: 4421.71231
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 7495.45164
-  tps: 4482.16205
+  dps: 7487.69233
+  tps: 4481.70752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 7481.58494
-  tps: 4479.02297
+  dps: 7459.60789
+  tps: 4464.01175
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 7534.20327
-  tps: 4492.59139
+  dps: 7518.86986
+  tps: 4484.9533
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 7611.50072
-  tps: 4557.49412
+  dps: 7578.7761
+  tps: 4547.11414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StormshroudArmor"
  value: {
-  dps: 5691.57379
-  tps: 3333.44937
+  dps: 5701.07818
+  tps: 3341.12655
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 7472.51919
-  tps: 4470.10948
+  dps: 7479.45077
+  tps: 4483.27645
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 7466.81249
-  tps: 4466.58156
+  dps: 7475.50123
+  tps: 4480.46371
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 7450.92549
-  tps: 4456.96934
+  dps: 7466.34823
+  tps: 4474.83905
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 7389.61959
-  tps: 4413.40777
+  dps: 7332.65641
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 7444.9335
-  tps: 4447.15179
+  dps: 7452.35871
+  tps: 4460.00768
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheFistsofFury"
  value: {
-  dps: 6575.51985
-  tps: 3905.85413
+  dps: 6541.59706
+  tps: 3888.89059
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 7389.61664
-  tps: 4413.40777
+  dps: 7332.66039
+  tps: 4382.32888
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 7338.4525
-  tps: 4375.73081
+  dps: 7329.07953
+  tps: 4373.92116
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thrall'sRegalia"
  value: {
-  dps: 6983.3748
-  tps: 4130.54109
+  dps: 6965.63188
+  tps: 4128.94161
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 7508.21509
-  tps: 4505.14489
+  dps: 7505.38194
+  tps: 4506.56403
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 5393.92405
-  tps: 3139.24242
+  dps: 5388.43721
+  tps: 3135.82788
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 7579.14344
-  tps: 4546.16669
+  dps: 7555.59296
+  tps: 4532.2803
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7603.16549
-  tps: 4564.11791
+  dps: 7586.08877
+  tps: 4564.97229
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 7459.00644
-  tps: 4460.53363
+  dps: 7476.2745
+  tps: 4480.1253
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 7454.40443
-  tps: 4457.8772
+  dps: 7471.6741
+  tps: 4477.46039
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 7528.82073
-  tps: 4499.62423
+  dps: 7516.61502
+  tps: 4502.26942
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 7822.61235
-  tps: 4706.91505
+  dps: 7767.6781
+  tps: 4678.72359
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 7724.26574
-  tps: 4627.37129
+  dps: 7684.73025
+  tps: 4611.22856
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 7859.63568
-  tps: 4707.68677
+  dps: 7827.14652
+  tps: 4699.16052
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 7591.47668
-  tps: 4552.6827
+  dps: 7608.46795
+  tps: 4573.94439
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 7454.40443
-  tps: 4457.8772
+  dps: 7471.6741
+  tps: 4477.46039
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 7459.00644
-  tps: 4460.53363
+  dps: 7476.2745
+  tps: 4480.1253
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 6035.11354
-  tps: 3558.66553
+  dps: 6036.42395
+  tps: 3564.58701
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 7796.40848
-  tps: 4670.05839
+  dps: 7798.81631
+  tps: 4675.67677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 7489.1794
-  tps: 4453.49953
+  dps: 7430.23385
+  tps: 4421.63895
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 7299.34324
-  tps: 4355.8107
+  dps: 7294.80072
+  tps: 4364.51857
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WorldbreakerGarb"
  value: {
-  dps: 7002.91762
-  tps: 4142.07004
+  dps: 6978.59213
+  tps: 4132.8927
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 7687.11487
-  tps: 4601.90384
+  dps: 7654.50387
+  tps: 4590.3599
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 7622.14919
-  tps: 4566.94854
+  dps: 7602.39759
+  tps: 4563.14953
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26252.08356
-  tps: 16120.25799
+  dps: 26214.2476
+  tps: 16124.9186
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7701.20581
-  tps: 4566.9409
+  dps: 7669.80712
+  tps: 4560.77359
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9598.39834
-  tps: 5022.75624
+  dps: 9574.68404
+  tps: 5036.32873
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13740.21042
-  tps: 9084.66179
+  dps: 13695.18093
+  tps: 9040.67234
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4005.97806
-  tps: 2337.07267
+  dps: 4003.62794
+  tps: 2340.78704
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5209.2813
-  tps: 2657.08313
+  dps: 5184.0533
+  tps: 2660.2416
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25723.85263
-  tps: 15851.54191
+  dps: 25632.30542
+  tps: 15680.34399
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7769.25604
-  tps: 4616.86615
+  dps: 7785.19309
+  tps: 4630.80867
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9631.61472
-  tps: 5050.64564
+  dps: 9652.83704
+  tps: 5090.78406
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13129.66512
-  tps: 8633.49726
+  dps: 13044.22996
+  tps: 8578.01815
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4075.16143
-  tps: 2385.26618
+  dps: 4042.52803
+  tps: 2368.6349
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5339.40536
-  tps: 2744.5652
+  dps: 5271.2156
+  tps: 2724.6169
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 26093.88551
-  tps: 16082.98965
+  dps: 26133.49621
+  tps: 16058.95898
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7667.77152
-  tps: 4547.62475
+  dps: 7644.295
+  tps: 4539.85052
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9557.93122
-  tps: 4991.45496
+  dps: 9609.50631
+  tps: 5070.27954
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13485.36539
-  tps: 8835.36366
+  dps: 13392.72935
+  tps: 8817.13797
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3991.78414
-  tps: 2326.96384
+  dps: 4006.7681
+  tps: 2343.06979
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-FT-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5241.00555
-  tps: 2685.94505
+  dps: 5240.91568
+  tps: 2718.50875
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21714.75966
-  tps: 13590.66955
+  dps: 21680.16437
+  tps: 13638.71484
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6547.24531
-  tps: 3878.69556
+  dps: 6507.784
+  tps: 3861.80638
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8499.82574
-  tps: 4358.20911
+  dps: 8428.97103
+  tps: 4349.02986
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10710.06309
-  tps: 7621.5976
+  dps: 10610.24642
+  tps: 7579.48976
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3005.34841
-  tps: 1802.63995
+  dps: 2968.93615
+  tps: 1778.93524
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4012.90624
-  tps: 2051.61538
+  dps: 3957.85135
+  tps: 2025.16372
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21065.44837
-  tps: 13151.10116
+  dps: 21032.76479
+  tps: 13230.12753
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6643.61018
-  tps: 3948.92383
+  dps: 6576.80932
+  tps: 3913.78725
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8622.18341
-  tps: 4446.86562
+  dps: 8516.56232
+  tps: 4409.27557
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9965.40096
-  tps: 7100.33822
+  dps: 10063.51092
+  tps: 7218.51259
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3054.05001
-  tps: 1836.84852
+  dps: 3037.8618
+  tps: 1827.22131
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4093.62997
-  tps: 2109.04655
+  dps: 4047.1475
+  tps: 2089.28001
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21351.24393
-  tps: 13284.68601
+  dps: 21374.01664
+  tps: 13399.67835
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6523.37897
-  tps: 3867.27459
+  dps: 6519.95465
+  tps: 3877.31261
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8436.46052
-  tps: 4326.26505
+  dps: 8411.63234
+  tps: 4372.2593
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10406.66007
-  tps: 7372.50749
+  dps: 10422.08541
+  tps: 7382.86132
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2989.97901
-  tps: 1786.62151
+  dps: 2981.21683
+  tps: 1783.52357
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-WF-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4069.84914
-  tps: 2100.22711
+  dps: 3991.83663
+  tps: 2064.13251
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25999.61061
-  tps: 16203.89454
+  dps: 25922.1375
+  tps: 16076.73195
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7602.92863
-  tps: 4557.46362
+  dps: 7633.96469
+  tps: 4585.87119
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9598.09372
-  tps: 5148.21929
+  dps: 9545.73434
+  tps: 5164.04585
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13395.66112
-  tps: 8927.78975
+  dps: 13369.43098
+  tps: 8956.67999
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3958.66628
-  tps: 2340.45956
+  dps: 3976.3167
+  tps: 2364.13851
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5167.33241
-  tps: 2731.19174
+  dps: 5122.08272
+  tps: 2715.87209
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25352.41952
-  tps: 15704.39296
+  dps: 25275.6347
+  tps: 15682.57916
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7677.36147
-  tps: 4608.91669
+  dps: 7720.34223
+  tps: 4643.49534
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9614.9434
-  tps: 5169.37493
+  dps: 9624.68112
+  tps: 5215.72835
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13030.02422
-  tps: 8687.76804
+  dps: 12885.50895
+  tps: 8572.43985
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4020.92961
-  tps: 2386.67431
+  dps: 4018.00444
+  tps: 2391.24806
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5234.60776
-  tps: 2768.7002
+  dps: 5198.75134
+  tps: 2761.36177
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25688.02763
-  tps: 15915.70844
+  dps: 25691.39525
+  tps: 15992.1555
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 7634.05546
-  tps: 4584.1121
+  dps: 7622.71979
+  tps: 4581.67101
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9504.19807
-  tps: 5100.44649
+  dps: 9438.30258
+  tps: 5075.60119
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13396.33471
-  tps: 8923.38525
+  dps: 13335.75761
+  tps: 8899.44018
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3932.26687
-  tps: 2322.48409
+  dps: 3962.98967
+  tps: 2349.64606
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-FT-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5132.53343
-  tps: 2692.67456
+  dps: 5131.35099
+  tps: 2723.9177
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21490.82995
-  tps: 13541.56512
+  dps: 21384.38777
+  tps: 13548.39071
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6509.20653
-  tps: 3884.38771
+  dps: 6514.51764
+  tps: 3900.36173
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8399.35603
-  tps: 4372.90673
+  dps: 8379.37137
+  tps: 4403.48572
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10522.8486
-  tps: 7551.64566
+  dps: 10416.80384
+  tps: 7502.68723
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2987.67205
-  tps: 1804.43259
+  dps: 2955.47922
+  tps: 1785.17477
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_ft-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3976.49024
-  tps: 2074.16866
+  dps: 3959.33256
+  tps: 2076.57379
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21026.11242
-  tps: 13307.26061
+  dps: 20990.67972
+  tps: 13266.53791
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6573.59916
-  tps: 3936.22657
+  dps: 6554.30878
+  tps: 3931.71223
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8480.31939
-  tps: 4434.26513
+  dps: 8471.25083
+  tps: 4465.71853
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9881.62652
-  tps: 7125.83611
+  dps: 9914.00758
+  tps: 7151.38029
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3034.2136
-  tps: 1840.12099
+  dps: 3022.61476
+  tps: 1832.60228
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-default_wf-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4025.91723
-  tps: 2105.66184
+  dps: 3986.52439
+  tps: 2093.66433
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21346.8757
-  tps: 13454.69915
+  dps: 21260.44814
+  tps: 13290.20528
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6486.87673
-  tps: 3869.62509
+  dps: 6449.72884
+  tps: 3857.26454
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8430.99203
-  tps: 4411.80671
+  dps: 8333.66807
+  tps: 4388.32522
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10299.51643
-  tps: 7357.83908
+  dps: 10399.48238
+  tps: 7461.54358
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-LongSingleTarget"
  value: {
-  dps: 2944.7252
-  tps: 1777.50606
+  dps: 2937.7638
+  tps: 1776.65144
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-WF-phase_3-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4032.31231
-  tps: 2121.08336
+  dps: 3993.04766
+  tps: 2107.34847
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 7264.74864
-  tps: 4326.98983
+  dps: 7271.21372
+  tps: 4333.37024
  }
 }

--- a/sim/shaman/fire_elemental_pet.go
+++ b/sim/shaman/fire_elemental_pet.go
@@ -89,7 +89,7 @@ func (fireElemental *FireElemental) Reset(_ *core.Simulation) {
 
 }
 
-func (fireElemental *FireElemental) OnGCDReady(sim *core.Simulation) {
+func (fireElemental *FireElemental) ExecuteCustomRotation(sim *core.Simulation) {
 	/*
 		TODO this is a little dirty, can probably clean this up, the rotation might go through some more overhauls,
 		the random AI is hard to emulate.
@@ -130,10 +130,6 @@ func (fireElemental *FireElemental) OnGCDReady(sim *core.Simulation) {
 
 func (fireElemental *FireElemental) TryCast(sim *core.Simulation, target *core.Unit, spell *core.Spell, maxCastCount int32) bool {
 	if maxCastCount == spell.SpellMetrics[0].Casts {
-		return false
-	}
-
-	if !spell.IsReady(sim) {
 		return false
 	}
 

--- a/sim/shaman/restoration/TestRestoration.results
+++ b/sim/shaman/restoration/TestRestoration.results
@@ -46,851 +46,851 @@ character_stats_results: {
 dps_results: {
  key: "TestRestoration-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 449.18267
+  dps: 438.74262
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 451.31913
+  dps: 440.81894
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 431.8527
+  dps: 421.75678
   hps: 93.56546
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 431.8527
+  dps: 421.75678
   hps: 93.56546
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Beast-tamer'sShoulders-30892"
  value: {
-  dps: 427.28247
+  dps: 417.58166
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Bizuri'sTotemofShatteredIce-50458"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BlackBruise-50035"
  value: {
-  dps: 383.06714
+  dps: 374.4883
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BlackBruise-50692"
  value: {
-  dps: 383.06714
+  dps: 374.4883
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 381.1461
+  dps: 372.35338
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 397.45843
+  dps: 388.58783
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 443.04449
+  dps: 432.77723
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 431.79961
+  dps: 421.84891
   hps: 64
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 435.05877
+  dps: 425.45728
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Death'sChoice-47464"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Defender'sCode-40257"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EarthshatterBattlegear"
  value: {
-  dps: 391.73754
+  dps: 384.11985
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EarthshatterGarb"
  value: {
-  dps: 442.04178
+  dps: 433.095
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 443.74706
+  dps: 433.46002
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 433.44589
+  dps: 423.67646
   tps: 0.975
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 442.57905
+  dps: 432.32489
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ForgeEmber-37660"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 443.04449
+  dps: 432.77723
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 442.55893
+  dps: 432.30534
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-FrostWitch'sBattlegear"
  value: {
-  dps: 401.98499
+  dps: 395.23715
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-FrostWitch'sRegalia"
  value: {
-  dps: 507.83099
+  dps: 497.92526
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-FuturesightRune-38763"
  value: {
-  dps: 437.82056
+  dps: 427.70036
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Gladiator'sEarthshaker"
  value: {
-  dps: 373.50479
+  dps: 365.19514
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Gladiator'sWartide"
  value: {
-  dps: 465.08147
+  dps: 454.19385
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 450.2509
+  dps: 439.78078
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 452.6787
+  dps: 442.14023
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 427.6979
-  dtps: 31.91045
+  dps: 422.07575
+  dtps: 32.22786
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Heartpierce-49982"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Heartpierce-50641"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-IncisorFragment-37723"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-LastWord-50179"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-LastWord-50708"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 442.57905
+  dps: 432.32489
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Nibelung-49992"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Nibelung-50648"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 446.36642
+  dps: 436.00565
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 448.11444
+  dps: 437.70446
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Shadowmourne-49623"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SkycallTotem-33506"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SkyshatterHarness"
  value: {
-  dps: 346.65976
+  dps: 338.77387
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SkyshatterRegalia"
  value: {
-  dps: 392.06671
+  dps: 382.87779
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 447.14332
+  dps: 436.76067
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 449.08556
+  dps: 438.64824
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SouloftheDead-40382"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SparkofLife-37657"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 442.98336
+  dps: 432.60699
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-StormshroudArmor"
  value: {
-  dps: 377.68282
+  dps: 368.87888
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 434.85872
+  dps: 425.26267
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TheFistsofFury"
  value: {
-  dps: 387.75043
+  dps: 379.15057
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 431.79961
+  dps: 421.84891
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Thrall'sBattlegear"
  value: {
-  dps: 401.11737
+  dps: 393.85565
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Thrall'sRegalia"
  value: {
-  dps: 470.94541
+  dps: 461.60137
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 440.61669
+  dps: 430.41777
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TidefuryRaiment"
  value: {
-  dps: 379.05999
+  dps: 370.22169
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 450.5255
+  dps: 439.95675
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 450.5255
+  dps: 439.95675
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 443.04449
+  dps: 432.77723
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 442.55893
+  dps: 432.30534
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 438.40323
+  dps: 428.26663
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TotemofElectrifyingWind-47666"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TotemoftheAvalanche-50463"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TotemoftheElementalPlane-40708"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 442.55893
+  dps: 432.30534
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 443.04449
+  dps: 432.77723
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 377.68282
+  dps: 368.87888
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 453.40738
+  dps: 442.98141
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-WingedTalisman-37844"
  value: {
-  dps: 465.40038
+  dps: 454.50379
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-WorldbreakerBattlegear"
  value: {
-  dps: 396.41325
+  dps: 389.7915
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-WorldbreakerGarb"
  value: {
-  dps: 465.74518
+  dps: 456.87971
  }
 }
 dps_results: {
  key: "TestRestoration-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-Average-Default"
  value: {
-  dps: 442.93462
+  dps: 433.28018
  }
 }
 dps_results: {
  key: "TestRestoration-Settings-Troll-p1-Standard-Default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 1998.26195
+  dps: 1991.73894
  }
 }
 dps_results: {
  key: "TestRestoration-Settings-Troll-p1-Standard-Default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 441.31659
+  dps: 431.09798
  }
 }
 dps_results: {
  key: "TestRestoration-Settings-Troll-p1-Standard-Default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 1149.59074
+  dps: 1119.20682
  }
 }
 dps_results: {
  key: "TestRestoration-Settings-Troll-p1-Standard-Default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 1517.94942
+  dps: 1513.25039
  }
 }
 dps_results: {
  key: "TestRestoration-Settings-Troll-p1-Standard-Default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 324.78607
+  dps: 317.58927
  }
 }
 dps_results: {
  key: "TestRestoration-Settings-Troll-p1-Standard-Default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 851.05887
+  dps: 832.65007
  }
 }
 dps_results: {
  key: "TestRestoration-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 402.44226
+  dps: 394.56405
  }
 }

--- a/sim/shaman/spirit_wolves.go
+++ b/sim/shaman/spirit_wolves.go
@@ -92,8 +92,7 @@ func (spiritWolf *SpiritWolf) Initialize() {
 	// Nothing
 }
 
-func (spiritWolf *SpiritWolf) OnGCDReady(_ *core.Simulation) {
-	spiritWolf.DoNothing()
+func (spiritWolf *SpiritWolf) ExecuteCustomRotation(_ *core.Simulation) {
 }
 
 func (spiritWolf *SpiritWolf) Reset(sim *core.Simulation) {

--- a/sim/warlock/TestAffliction.results
+++ b/sim/warlock/TestAffliction.results
@@ -46,780 +46,738 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 14532.12718
-  tps: 13402.16189
+  dps: 14511.32773
+  tps: 13387.90697
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 14587.7418
-  tps: 13453.89144
+  dps: 14562.80757
+  tps: 13434.80289
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 14354.61133
-  tps: 13231.66862
+  dps: 14333.03629
+  tps: 13217.76593
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 14102.87006
-  tps: 12995.52847
-  hps: 101.60403
+  dps: 14073.25134
+  tps: 12969.79909
+  hps: 101.51089
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 14102.87006
-  tps: 12995.52847
-  hps: 101.60403
+  dps: 14073.25134
+  tps: 12969.79909
+  hps: 101.51089
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 14745.04414
-  tps: 13613.86083
+  dps: 14740.46359
+  tps: 13611.18595
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 10582.43435
-  tps: 9649.96641
+  dps: 10692.38966
+  tps: 9766.54996
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 14755.68102
-  tps: 13350.78411
+  dps: 14739.10745
+  tps: 13337.57692
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 15089.13707
-  tps: 13958.16817
+  dps: 15067.41872
+  tps: 13941.05133
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
   hps: 64
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 13593.26697
-  tps: 12498.20172
+  dps: 13582.19577
+  tps: 12479.24179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 14187.30144
-  tps: 13077.05597
+  dps: 14195.46141
+  tps: 13088.08605
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 14289.22352
-  tps: 13181.52859
+  dps: 14308.10296
+  tps: 13199.41742
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 14209.88121
-  tps: 13089.90289
+  dps: 14196.38261
+  tps: 13078.58114
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Death'sChoice-47464"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 14159.31489
-  tps: 13050.99243
+  dps: 14130.5756
+  tps: 13027.35395
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeathbringerGarb"
  value: {
-  dps: 11650.43747
-  tps: 10622.86736
+  dps: 11579.74297
+  tps: 10548.73563
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Defender'sCode-40257"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 14736.58505
-  tps: 13605.61615
+  dps: 14712.4428
+  tps: 13586.07541
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 14996.46395
-  tps: 13870.79952
+  dps: 14970.81044
+  tps: 13847.65573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 14794.3012
-  tps: 13659.96837
+  dps: 14793.49861
+  tps: 13661.46684
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 14731.4596
-  tps: 13600.4907
+  dps: 14708.2199
+  tps: 13581.85252
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 14725.54255
-  tps: 13594.57365
+  dps: 14702.80925
+  tps: 13576.44187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 14321.15239
-  tps: 13215.63206
+  dps: 14282.17448
+  tps: 13177.24897
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 14348.90038
-  tps: 13243.95278
+  dps: 14291.83759
+  tps: 13189.42967
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 14564.89863
-  tps: 13441.19126
+  dps: 14503.8997
+  tps: 13384.77604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 14130.19689
-  tps: 13017.96204
+  dps: 14067.91756
+  tps: 12962.42662
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 14367.56257
-  tps: 13245.62365
+  dps: 14332.22049
+  tps: 13215.37823
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForgeEmber-37660"
  value: {
-  dps: 14404.81624
-  tps: 13286.19418
+  dps: 14372.07155
+  tps: 13260.91646
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 14755.68102
-  tps: 13621.27189
+  dps: 14739.10745
+  tps: 13607.79652
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 14743.43337
-  tps: 13609.60132
+  dps: 14731.50049
+  tps: 13601.04589
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuturesightRune-38763"
  value: {
-  dps: 14329.20709
-  tps: 13211.02531
+  dps: 14260.55412
+  tps: 13145.91986
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 11344.51693
-  tps: 10346.99931
+  dps: 11393.13971
+  tps: 10398.78645
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 14560.53034
-  tps: 13429.15609
+  dps: 14527.72343
+  tps: 13400.71901
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 14632.80567
-  tps: 13496.33259
+  dps: 14600.433
+  tps: 13470.16433
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 14326.63686
-  tps: 13223.84466
+  dps: 14290.63959
+  tps: 13184.69115
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 11950.03274
-  tps: 10808.02752
+  dps: 11932.98473
+  tps: 10794.77048
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 14571.67914
-  tps: 13438.74422
+  dps: 14548.53165
+  tps: 13421.40929
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 14731.4596
-  tps: 13600.4907
+  dps: 14708.2199
+  tps: 13581.85252
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 14725.54255
-  tps: 13594.57365
+  dps: 14702.80925
+  tps: 13576.44187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IncisorFragment-37723"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 14710.22974
-  tps: 13577.65363
+  dps: 14726.4468
+  tps: 13596.10839
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 14346.29996
-  tps: 13225.54578
+  dps: 14296.75638
+  tps: 13181.09873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MaleficRaiment"
  value: {
-  dps: 8772.95422
-  tps: 7865.02912
+  dps: 8758.04595
+  tps: 7851.34564
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 14215.7938
-  tps: 13107.47134
+  dps: 14191.99081
+  tps: 13088.76917
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 14752.0621
-  tps: 13632.47425
+  dps: 14691.41797
+  tps: 13568.59622
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PlagueheartGarb"
  value: {
-  dps: 11029.70303
-  tps: 10032.86984
+  dps: 11003.31309
+  tps: 10005.31905
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 14631.73729
-  tps: 13511.15224
+  dps: 14585.78946
+  tps: 13467.71777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 14683.46848
-  tps: 13560.40485
+  dps: 14648.40549
+  tps: 13527.46191
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 15056.8563
-  tps: 13925.8874
+  dps: 15038.13896
+  tps: 13911.77157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 14712.40862
-  tps: 13580.66806
+  dps: 14705.82781
+  tps: 13576.74391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 14512.3744
-  tps: 13388.13321
+  dps: 14451.58258
+  tps: 13326.34821
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 14542.70136
-  tps: 13415.6071
+  dps: 14520.81756
+  tps: 13394.56246
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulPreserver-37111"
  value: {
-  dps: 14298.97625
-  tps: 13180.67101
+  dps: 14239.92869
+  tps: 13126.82695
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SouloftheDead-40382"
  value: {
-  dps: 14270.61247
-  tps: 13164.99685
+  dps: 14197.93645
+  tps: 13092.03976
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SparkofLife-37657"
  value: {
-  dps: 14321.71735
-  tps: 13213.62422
+  dps: 14228.98806
+  tps: 13125.26886
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 14110.97691
-  tps: 13000.31875
+  dps: 14084.41203
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 14213.66854
-  tps: 13100.50413
+  dps: 14159.76444
+  tps: 13050.95615
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 14150.10635
-  tps: 13038.55873
+  dps: 14110.06758
+  tps: 12999.28808
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 14108.64121
-  tps: 13000.31875
+  dps: 14082.11381
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 14701.84421
-  tps: 13570.87531
+  dps: 14681.35774
+  tps: 13554.99035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 14113.23887
-  tps: 13000.31875
+  dps: 14086.66345
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 14113.23887
-  tps: 13000.31875
+  dps: 14086.66345
+  tps: 12978.89216
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 14755.68102
-  tps: 13621.27189
+  dps: 14739.10745
+  tps: 13607.79652
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 14743.43337
-  tps: 13609.60132
+  dps: 14731.50049
+  tps: 13601.04589
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 14392.10629
-  tps: 13279.24978
+  dps: 14366.59566
+  tps: 13251.6155
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 14743.43337
-  tps: 13609.60132
+  dps: 14731.50049
+  tps: 13601.04589
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 14755.68102
-  tps: 13621.27189
+  dps: 14739.10745
+  tps: 13607.79652
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WingedTalisman-37844"
  value: {
-  dps: 14285.24711
-  tps: 13168.80239
+  dps: 14263.87463
+  tps: 13152.75435
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 15201.06628
-  tps: 14066.48026
- }
-}
-dps_results: {
- key: "TestAffliction-Settings-Orc-p4_affliction-AffItemSwap--FullBuffs-LongMultiTarget"
- value: {
-  dps: 37704.28518
-  tps: 43368.51946
- }
-}
-dps_results: {
- key: "TestAffliction-Settings-Orc-p4_affliction-AffItemSwap--FullBuffs-LongSingleTarget"
- value: {
-  dps: 15075.37053
-  tps: 13948.48929
- }
-}
-dps_results: {
- key: "TestAffliction-Settings-Orc-p4_affliction-AffItemSwap--FullBuffs-ShortSingleTarget"
- value: {
-  dps: 16509.72185
-  tps: 15329.92017
- }
-}
-dps_results: {
- key: "TestAffliction-Settings-Orc-p4_affliction-AffItemSwap--NoBuffs-LongMultiTarget"
- value: {
-  dps: 23075.07508
-  tps: 29011.85942
- }
-}
-dps_results: {
- key: "TestAffliction-Settings-Orc-p4_affliction-AffItemSwap--NoBuffs-LongSingleTarget"
- value: {
-  dps: 9069.77767
-  tps: 8658.99455
- }
-}
-dps_results: {
- key: "TestAffliction-Settings-Orc-p4_affliction-AffItemSwap--NoBuffs-ShortSingleTarget"
- value: {
-  dps: 8679.63662
-  tps: 8155.61814
+  dps: 15162.65295
+  tps: 14026.86872
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4_affliction-Affliction Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 39808.07096
-  tps: 45611.29526
+  dps: 39536.83662
+  tps: 45256.29079
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4_affliction-Affliction Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 15089.13707
-  tps: 13958.16817
+  dps: 15067.41872
+  tps: 13941.05133
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4_affliction-Affliction Warlock--FullBuffs-ShortSingleTarget"
  value: {
   dps: 16484.65086
-  tps: 15302.448
+  tps: 15240.7683
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4_affliction-Affliction Warlock--NoBuffs-LongMultiTarget"
  value: {
-  dps: 24462.22984
+  dps: 24462.18518
   tps: 30517.14225
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4_affliction-Affliction Warlock--NoBuffs-LongSingleTarget"
  value: {
-  dps: 9061.67313
-  tps: 8650.0198
+  dps: 9062.40128
+  tps: 8651.2258
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4_affliction-Affliction Warlock--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8750.39993
+  dps: 8750.10302
   tps: 8230.0116
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 15042.64073
-  tps: 13958.16817
+  dps: 15020.99636
+  tps: 13941.05133
  }
 }

--- a/sim/warlock/TestDemonology.results
+++ b/sim/warlock/TestDemonology.results
@@ -46,780 +46,780 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 13497.7276
-  tps: 11741.44239
+  dps: 13398.71247
+  tps: 11642.2407
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 13543.53666
-  tps: 11782.59883
+  dps: 13457.75607
+  tps: 11696.59018
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AshtongueTalismanofShadows-32493"
  value: {
-  dps: 13340.46035
-  tps: 11599.56869
+  dps: 13237.24555
+  tps: 11495.5954
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 13677.47532
-  tps: 11902.94816
+  dps: 13618.50885
+  tps: 11844.6303
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 13141.88404
-  tps: 11421.87412
-  hps: 102.25224
+  dps: 13061.88788
+  tps: 11340.51615
+  hps: 102.26501
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 13141.88404
-  tps: 11421.87412
-  hps: 102.25224
+  dps: 13061.88788
+  tps: 11340.51615
+  hps: 102.26501
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 13692.63545
-  tps: 11918.92872
+  dps: 13645.89567
+  tps: 11867.51798
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 9985.13305
-  tps: 8527.24271
+  dps: 9961.95216
+  tps: 8502.83202
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 13722.21673
-  tps: 11707.06802
+  dps: 13650.88076
+  tps: 11638.25864
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 14041.51007
-  tps: 12267.92152
+  dps: 13987.5195
+  tps: 12214.7474
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 13201.9801
-  tps: 11475.60734
+  dps: 13104.0453
+  tps: 11377.08051
   hps: 64
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkCoven'sRegalia"
  value: {
-  dps: 12816.2559
-  tps: 11120.67984
+  dps: 12749.38966
+  tps: 11056.49084
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 13290.67701
-  tps: 11571.42682
+  dps: 13227.96305
+  tps: 11506.73742
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 13324.96915
-  tps: 11605.60732
+  dps: 13274.51502
+  tps: 11553.05609
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 13264.48317
-  tps: 11538.22872
+  dps: 13232.58094
+  tps: 11502.85868
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Death'sChoice-47464"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 13181.15808
-  tps: 11461.90789
+  dps: 13117.09825
+  tps: 11395.87262
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeathbringerGarb"
  value: {
-  dps: 10888.3766
-  tps: 9318.47879
+  dps: 10861.53503
+  tps: 9292.47367
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Defender'sCode-40257"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 13705.11601
-  tps: 11931.52747
+  dps: 13653.89912
+  tps: 11881.12703
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 13972.36209
-  tps: 12203.75815
+  dps: 13913.88156
+  tps: 12147.92784
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 13677.47532
-  tps: 11902.94816
+  dps: 13618.50885
+  tps: 11844.6303
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 13736.70969
-  tps: 11957.78566
+  dps: 13681.96021
+  tps: 11898.31268
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 13698.58149
-  tps: 11924.99294
+  dps: 13646.80946
+  tps: 11874.03736
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 13690.50908
-  tps: 11916.92053
+  dps: 13638.20448
+  tps: 11865.43239
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 13300.90275
-  tps: 11582.04609
+  dps: 13275.41935
+  tps: 11556.53738
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 13165.39592
-  tps: 11442.37812
+  dps: 13094.44365
+  tps: 11370.53633
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 13318.53013
-  tps: 11599.22642
+  dps: 13278.87732
+  tps: 11557.64178
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 13549.788
-  tps: 11803.66689
+  dps: 13439.3557
+  tps: 11692.2077
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 13165.3031
-  tps: 11441.32699
+  dps: 13088.93784
+  tps: 11366.42516
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 13358.3369
-  tps: 11615.97732
+  dps: 13262.66735
+  tps: 11519.40157
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForgeEmber-37660"
  value: {
-  dps: 13500.08894
-  tps: 11754.47678
+  dps: 13411.2683
+  tps: 11665.37436
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 13722.21673
-  tps: 11943.7211
+  dps: 13650.88076
+  tps: 11873.48979
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 13711.52867
-  tps: 11934.06582
+  dps: 13643.4329
+  tps: 11867.50511
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuturesightRune-38763"
  value: {
-  dps: 13326.36447
-  tps: 11587.23475
+  dps: 13246.58593
+  tps: 11506.45931
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 10683.88051
-  tps: 9108.68861
+  dps: 10673.45711
+  tps: 9098.00344
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 13521.1659
-  tps: 11762.30842
+  dps: 13427.03034
+  tps: 11668.14758
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 13570.04752
-  tps: 11806.61697
+  dps: 13480.60378
+  tps: 11716.87255
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 13272.58201
-  tps: 11552.5503
+  dps: 13256.54607
+  tps: 11535.16707
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gul'dan'sRegalia"
  value: {
-  dps: 11212.34679
-  tps: 9472.84466
+  dps: 11182.97822
+  tps: 9441.97399
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 13531.95434
-  tps: 11771.78868
+  dps: 13446.52278
+  tps: 11686.12668
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 13698.58149
-  tps: 11924.99294
+  dps: 13646.80946
+  tps: 11874.03736
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 13690.50908
-  tps: 11916.92053
+  dps: 13638.20448
+  tps: 11865.43239
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IncisorFragment-37723"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 13702.25439
-  tps: 11928.39328
+  dps: 13659.16364
+  tps: 11884.88797
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 13369.46526
-  tps: 11626.18497
+  dps: 13270.01317
+  tps: 11525.92058
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MaleficRaiment"
  value: {
-  dps: 8546.1611
-  tps: 7184.08708
+  dps: 8519.01257
+  tps: 7156.3046
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 13243.40118
-  tps: 11524.15099
+  dps: 13179.62884
+  tps: 11458.40321
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 13428.33838
-  tps: 11685.9788
+  dps: 13330.7384
+  tps: 11587.47263
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PlagueheartGarb"
  value: {
-  dps: 10347.19469
-  tps: 8815.02901
+  dps: 10376.20886
+  tps: 8842.51237
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 13674.59825
-  tps: 11900.14969
+  dps: 13617.04579
+  tps: 11843.31209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 13677.47532
-  tps: 11902.94816
+  dps: 13618.50885
+  tps: 11844.6303
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 13657.25906
-  tps: 11907.06203
+  dps: 13596.24878
+  tps: 11845.32659
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 13734.03811
-  tps: 11980.25779
+  dps: 13677.02952
+  tps: 11922.70067
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 14004.54274
-  tps: 12230.9542
+  dps: 13947.54146
+  tps: 12174.76937
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 13671.37602
-  tps: 11897.84385
+  dps: 13612.20027
+  tps: 11836.87842
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 13201.9801
-  tps: 11475.60734
+  dps: 13104.0453
+  tps: 11377.08051
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 13427.39457
-  tps: 11677.05013
+  dps: 13421.37789
+  tps: 11667.14831
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 13501.88027
-  tps: 11749.52489
+  dps: 13470.09251
+  tps: 11710.50259
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulPreserver-37111"
  value: {
-  dps: 13281.51216
-  tps: 11546.58448
+  dps: 13199.78401
+  tps: 11463.7988
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SouloftheDead-40382"
  value: {
-  dps: 13302.21002
-  tps: 11584.17688
+  dps: 13253.30103
+  tps: 11531.57748
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SparkofLife-37657"
  value: {
-  dps: 13293.2717
-  tps: 11567.29742
+  dps: 13246.51389
+  tps: 11522.47221
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 13150.53818
-  tps: 11417.34593
+  dps: 13083.86635
+  tps: 11347.46178
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 13240.09816
-  tps: 11510.9332
+  dps: 13132.15417
+  tps: 11401.78715
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 13185.80648
-  tps: 11462.10098
+  dps: 13144.64621
+  tps: 11419.32194
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 13140.87418
-  tps: 11421.62399
+  dps: 13065.38912
+  tps: 11344.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 13664.66651
-  tps: 11891.07797
+  dps: 13610.13237
+  tps: 11837.36027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 13151.56906
-  tps: 11411.57692
+  dps: 13090.578
+  tps: 11347.62186
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 13151.56906
-  tps: 11411.57692
+  dps: 13090.578
+  tps: 11347.62186
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 13722.21673
-  tps: 11943.7211
+  dps: 13650.88076
+  tps: 11873.48979
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 13711.52867
-  tps: 11934.06582
+  dps: 13643.4329
+  tps: 11867.50511
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 13379.8549
-  tps: 11649.66023
+  dps: 13349.72783
+  tps: 11616.30091
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 13711.52867
-  tps: 11934.06582
+  dps: 13643.4329
+  tps: 11867.50511
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 13722.21673
-  tps: 11943.7211
+  dps: 13650.88076
+  tps: 11873.48979
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WingedTalisman-37844"
  value: {
-  dps: 13347.56765
-  tps: 11608.22594
+  dps: 13251.29895
+  tps: 11511.3227
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 14180.83481
-  tps: 12390.56753
+  dps: 14137.37307
+  tps: 12346.93575
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 42641.297
-  tps: 47669.4068
+  dps: 42455.26764
+  tps: 47419.50755
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 14041.51007
-  tps: 12267.92152
+  dps: 13987.5195
+  tps: 12214.7474
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15962.92788
-  tps: 13951.9136
+  dps: 15962.94522
+  tps: 13894.83684
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--NoBuffs-LongMultiTarget"
  value: {
-  dps: 26070.68928
-  tps: 32052.2305
+  dps: 26072.57713
+  tps: 32054.04867
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--NoBuffs-LongSingleTarget"
  value: {
-  dps: 8161.57471
-  tps: 7550.65667
+  dps: 8161.39757
+  tps: 7550.43655
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock--NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8624.86953
-  tps: 7869.42473
+  dps: 8625.56831
+  tps: 7869.94012
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17427.42112
-  tps: 17328.35933
+  dps: 17438.86787
+  tps: 17278.70009
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-FullBuffs-LongSingleTarget"
  value: {
-  dps: 14003.20292
-  tps: 12229.92701
+  dps: 13987.55061
+  tps: 12211.3241
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15867.93506
-  tps: 13858.27991
+  dps: 15867.80813
+  tps: 13801.53668
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10675.53929
+  dps: 10675.54295
   tps: 12403.23872
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-NoBuffs-LongSingleTarget"
  value: {
-  dps: 8149.86636
-  tps: 7533.88826
+  dps: 8150.0904
+  tps: 7534.10248
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p4_demo-Demonology Warlock-demo-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8579.73062
+  dps: 8579.77973
   tps: 7822.12309
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 13914.62432
-  tps: 12286.01562
+  dps: 13841.74413
+  tps: 12215.01764
  }
 }

--- a/sim/warlock/TestDestruction.results
+++ b/sim/warlock/TestDestruction.results
@@ -47,42 +47,42 @@ dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50359"
  value: {
   dps: 13375.22942
-  tps: 11127.08179
+  tps: 11125.441
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
   dps: 13421.27737
-  tps: 11166.50821
+  tps: 11164.88667
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AshtongueTalismanofShadows-32493"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereEarthsiegeDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bandit'sInsignia-40371"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50354"
  value: {
   dps: 13003.46841
-  tps: 10809.20113
+  tps: 10807.29902
   hps: 101.62631
  }
 }
@@ -90,7 +90,7 @@ dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
   dps: 13003.46841
-  tps: 10809.20113
+  tps: 10807.29902
   hps: 101.62631
  }
 }
@@ -98,49 +98,49 @@ dps_results: {
  key: "TestDestruction-AllItems-BeamingEarthsiegeDiamond"
  value: {
   dps: 13370.59632
-  tps: 11125.19014
+  tps: 11123.32118
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 10023.81371
-  tps: 8245.19754
+  dps: 10032.21269
+  tps: 8248.22603
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingEarthsiegeDiamond"
  value: {
   dps: 13390.45819
-  tps: 10920.23654
+  tps: 10918.10903
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 13807.95102
-  tps: 11518.264
+  tps: 11516.11462
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50352"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorrodedSkeletonKey-50356"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
   hps: 64
  }
 }
@@ -148,616 +148,616 @@ dps_results: {
  key: "TestDestruction-AllItems-DarkCoven'sRegalia"
  value: {
   dps: 12417.24973
-  tps: 10295.69043
+  tps: 10294.05565
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
   dps: 13137.16724
-  tps: 10929.26187
+  tps: 10927.40193
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Death-42990"
  value: {
   dps: 13156.52938
-  tps: 10961.85793
+  tps: 10960.00892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Greatness-44255"
  value: {
   dps: 13092.65368
-  tps: 10891.60833
+  tps: 10890.64854
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Death'sChoice-47464"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathKnight'sAnguish-38212"
  value: {
   dps: 13042.34733
-  tps: 10843.88212
+  tps: 10842.02217
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50362"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeathbringerGarb"
  value: {
-  dps: 10901.44056
-  tps: 8981.31062
+  dps: 10900.1199
+  tps: 8974.86845
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Defender'sCode-40257"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveSkyflareDiamond"
  value: {
   dps: 13378.87214
-  tps: 11132.09301
+  tps: 11129.94363
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50353"
  value: {
   dps: 13689.08784
-  tps: 11423.0226
+  tps: 11420.75114
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentSkyflareDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberSkyflareDiamond"
  value: {
   dps: 13400.86589
-  tps: 11149.27347
+  tps: 11147.40104
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticSkyflareDiamond"
  value: {
   dps: 13370.59632
-  tps: 11124.64477
+  tps: 11122.49539
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticStarflareDiamond"
  value: {
   dps: 13360.54675
-  tps: 11115.60016
+  tps: 11113.45078
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EphemeralSnowflake-50260"
  value: {
   dps: 13122.01605
-  tps: 10920.5476
+  tps: 10918.3607
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceofGossamer-37220"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalEarthsiegeDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ExtractofNecromanticPower-40373"
  value: {
   dps: 13171.89068
-  tps: 10972.79292
+  tps: 10970.93297
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeoftheBroodmother-45308"
  value: {
   dps: 13392.45106
-  tps: 11147.07492
+  tps: 11145.38218
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-SapphireOwl-42413"
  value: {
   dps: 13023.24846
-  tps: 10826.4604
+  tps: 10824.894
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForethoughtTalisman-40258"
  value: {
   dps: 13232.8994
-  tps: 11005.21653
+  tps: 11003.50004
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForgeEmber-37660"
  value: {
   dps: 13297.37269
-  tps: 11064.75669
+  tps: 11062.99426
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornSkyflareDiamond"
  value: {
   dps: 13390.45819
-  tps: 11140.24899
+  tps: 11138.12148
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornStarflareDiamond"
  value: {
   dps: 13380.10954
-  tps: 11131.38956
+  tps: 11129.25768
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryoftheFiveFlights-40431"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuturesightRune-38763"
  value: {
   dps: 13182.68633
-  tps: 10962.27856
+  tps: 10960.50059
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
   dps: 10520.06042
-  tps: 8649.35357
+  tps: 8644.87496
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54573"
  value: {
   dps: 13398.25339
-  tps: 11146.79521
+  tps: 11145.16404
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
   dps: 13450.58061
-  tps: 11191.59627
+  tps: 11189.98698
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GnomishLightningGenerator-41121"
  value: {
   dps: 13127.68332
-  tps: 10941.42482
+  tps: 10939.52271
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gul'dan'sRegalia"
  value: {
   dps: 11177.75413
-  tps: 9132.64389
+  tps: 9129.40732
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 13411.14515
-  tps: 11157.57843
+  tps: 11155.95601
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveSkyflareDiamond"
  value: {
   dps: 13370.59632
-  tps: 11124.64477
+  tps: 11122.49539
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveStarflareDiamond"
  value: {
   dps: 13360.54675
-  tps: 11115.60016
+  tps: 11113.45078
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IncisorFragment-37723"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsightfulEarthsiegeDiamond"
  value: {
   dps: 13345.91364
-  tps: 11106.27605
+  tps: 11104.97211
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Lavanthor'sTalisman-37872"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MajesticDragonFigurine-40430"
  value: {
   dps: 13240.38552
-  tps: 11011.44785
+  tps: 11009.73698
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MaleficRaiment"
  value: {
-  dps: 8397.57213
-  tps: 6792.36333
+  dps: 8350.76197
+  tps: 6748.3223
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MeteoriteWhetstone-37390"
  value: {
   dps: 13100.66277
-  tps: 10896.38273
+  tps: 10894.52278
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NevermeltingIceCrystal-50259"
  value: {
   dps: 13273.21006
-  tps: 11041.49613
+  tps: 11039.77963
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OfferingofSacrifice-37638"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthshatterDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PersistentEarthsiegeDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedScarab-21685"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54571"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PlagueheartGarb"
  value: {
-  dps: 10105.45303
-  tps: 8273.19018
+  dps: 10098.17903
+  tps: 8260.86346
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthshatterDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulEarthsiegeDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PurifiedShardoftheGods"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReignoftheDead-47316"
  value: {
   dps: 13545.74716
-  tps: 11313.93785
+  tps: 11312.26218
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReignoftheDead-47477"
  value: {
   dps: 13617.77957
-  tps: 11380.57218
+  tps: 11378.91341
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelentlessEarthsiegeDiamond"
  value: {
   dps: 13773.20034
-  tps: 11486.98838
+  tps: 11484.839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingSkyflareDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.55732
+  tps: 11093.55412
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofRepulsion-40372"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SealofthePantheon-36993"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShinyShardoftheGods"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50339"
  value: {
   dps: 13331.27456
-  tps: 11092.79314
+  tps: 11091.62501
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SliverofPureIce-50346"
  value: {
   dps: 13373.13633
-  tps: 11128.97094
+  tps: 11127.87663
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulPreserver-37111"
  value: {
   dps: 13157.54821
-  tps: 10940.69903
+  tps: 10938.9387
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SouloftheDead-40382"
  value: {
   dps: 13127.52186
-  tps: 10924.5031
+  tps: 10923.7021
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SparkofLife-37657"
  value: {
   dps: 13085.94248
-  tps: 10885.67211
+  tps: 10883.98426
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftSkyflareDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftStarflareDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwiftWindfireDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofTrollDivinity-37734"
  value: {
   dps: 13099.73082
-  tps: 10891.17865
+  tps: 10889.38126
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearsoftheVanquished-47215"
  value: {
   dps: 13038.85465
-  tps: 10839.53285
+  tps: 10838.26786
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheGeneral'sHeart-45507"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ThunderingSkyflareDiamond"
  value: {
   dps: 13338.71496
-  tps: 11095.95154
+  tps: 11093.80216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50351"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 13000.56656
-  tps: 10806.27943
+  tps: 10804.41948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessSkyflareDiamond"
  value: {
   dps: 13390.45819
-  tps: 11140.24899
+  tps: 11138.12148
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TirelessStarflareDiamond"
  value: {
   dps: 13380.10954
-  tps: 11131.38956
+  tps: 11129.25768
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TomeofArcanePhenomena-36972"
  value: {
   dps: 13192.44664
-  tps: 10979.31352
+  tps: 10977.25642
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthshatterDiamond"
  value: {
   dps: 13380.10954
-  tps: 11131.38956
+  tps: 11129.25768
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrenchantEarthsiegeDiamond"
  value: {
   dps: 13390.45819
-  tps: 11140.24899
+  tps: 11138.12148
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WingedTalisman-37844"
  value: {
   dps: 13152.24225
-  tps: 10936.31291
+  tps: 10934.45296
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 13940.66725
-  tps: 11627.70004
+  dps: 13940.66165
+  tps: 11625.17376
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 30971.48173
-  tps: 36793.70589
+  dps: 30773.38912
+  tps: 36527.25591
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock--FullBuffs-LongSingleTarget"
  value: {
   dps: 13807.95102
-  tps: 11518.264
+  tps: 11516.11462
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock--FullBuffs-ShortSingleTarget"
  value: {
   dps: 15202.7866
-  tps: 12629.69341
+  tps: 12622.54313
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock--NoBuffs-LongMultiTarget"
  value: {
-  dps: 18693.67032
-  tps: 24903.9459
+  dps: 18693.61001
+  tps: 24903.94117
  }
 }
 dps_results: {
@@ -777,49 +777,49 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock-destro-FullBuffs-LongMultiTarget"
  value: {
-  dps: 14998.65423
-  tps: 14400.4639
+  dps: 13954.55789
+  tps: 14157.31002
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock-destro-FullBuffs-LongSingleTarget"
  value: {
-  dps: 13845.61371
-  tps: 11386.22808
+  dps: 13740.25849
+  tps: 11372.58946
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock-destro-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15633.44212
-  tps: 12300.02105
+  dps: 15068.92765
+  tps: 12278.35906
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock-destro-NoBuffs-LongMultiTarget"
  value: {
-  dps: 8952.3178
-  tps: 9227.11703
+  dps: 8209.33353
+  tps: 9209.54336
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock-destro-NoBuffs-LongSingleTarget"
  value: {
-  dps: 8118.24379
-  tps: 6869.56508
+  dps: 8032.67391
+  tps: 6857.94063
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p4_destro-Destruction Warlock-destro-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8690.19404
-  tps: 6913.61161
+  dps: 8236.29
+  tps: 6852.70425
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
   dps: 13807.95102
-  tps: 11518.264
+  tps: 11516.11462
  }
 }

--- a/sim/warlock/inferno.go
+++ b/sim/warlock/inferno.go
@@ -190,7 +190,6 @@ func (infernal *InfernalPet) Initialize() {
 func (infernal *InfernalPet) Reset(_ *core.Simulation) {
 }
 
-func (infernal *InfernalPet) OnGCDReady(sim *core.Simulation) {
+func (infernal *InfernalPet) ExecuteCustomRotation(sim *core.Simulation) {
 	infernal.immolationAura.Cast(sim, nil)
-	infernal.DoNothing()
 }

--- a/sim/warlock/pet.go
+++ b/sim/warlock/pet.go
@@ -298,7 +298,7 @@ func (wp *WarlockPet) Initialize() {
 func (wp *WarlockPet) Reset(_ *core.Simulation) {
 }
 
-func (wp *WarlockPet) OnGCDReady(sim *core.Simulation) {
+func (wp *WarlockPet) ExecuteCustomRotation(sim *core.Simulation) {
 	if !wp.primaryAbility.IsReady(sim) {
 		wp.WaitUntil(sim, wp.primaryAbility.CD.ReadyAt())
 		return
@@ -307,7 +307,6 @@ func (wp *WarlockPet) OnGCDReady(sim *core.Simulation) {
 	if success := wp.primaryAbility.Cast(sim, wp.CurrentTarget); !success {
 		wp.WaitForMana(sim, wp.primaryAbility.CurCast.Cost)
 	}
-
 }
 
 func (warlock *Warlock) makeStatInheritance() core.PetStatInheritance {

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -27,6 +27,7 @@ import {
 	APLActionItemSwap,
 	APLActionItemSwap_SwapSet as ItemSwapSet,
 
+	APLActionCustomRotation,
 	APLActionCatOptimalRotationAction,
 
 	APLValue,
@@ -567,6 +568,16 @@ const actionKindFactories: {[f in NonNullable<APLActionKind>]: ActionKindConfig<
 		newValue: () => APLActionItemSwap.create(),
 		fields: [
 			itemSwapSetFieldConfig('swapSet'),
+		],
+	}),
+
+	['customRotation']: inputBuilder({
+		label: 'Custom Rotation',
+		//submenu: ['Misc'],
+		shortDescription: 'INTERNAL ONLY',
+		includeIf: (player: Player<any>, isPrepull: boolean) => false, // Never show this, because its internal only.
+		newValue: () => APLActionCustomRotation.create(),
+		fields: [
 		],
 	}),
 


### PR DESCRIPTION
This will allow some more core unit code to be unified once legacy rotations are deprecated.