### PR TITLE
fix check of meta socket gems

### DIFF
--- a/sim/core/database.go
+++ b/sim/core/database.go
@@ -396,7 +396,7 @@ func ColorIntersects(g proto.GemColor, o proto.GemColor) bool {
 		return true
 	}
 	if g == proto.GemColor_GemColorMeta {
-		return o == proto.GemColor_GemColorUnknown
+		return o == proto.GemColor_GemColorMeta
 	}
 	if g == proto.GemColor_GemColorRed {
 		return o == proto.GemColor_GemColorOrange || o == proto.GemColor_GemColorPurple


### PR DESCRIPTION
Fix for #4002 

Test: Verified hit (or any other socket bonus) updated correctly with metagem and did not update with no metagem