### PR TITLE
Set NewDrw to true in dk tank sim

### DIFF
--- a/sim/deathknight/tank/tank_deathknight.go
+++ b/sim/deathknight/tank/tank_deathknight.go
@@ -39,6 +39,7 @@ func NewTankDeathknight(character *core.Character, options *proto.Player) *TankD
 	tankDk := &TankDeathknight{
 		Deathknight: deathknight.NewDeathknight(character, deathknight.DeathknightInputs{
 			IsDps:              false,
+			NewDrw:             true,
 			StartingRunicPower: dkOptions.Options.StartingRunicPower,
 		}, options.TalentsString, false),
 		Rotation: dkOptions.Rotation,


### PR DESCRIPTION
`NewDrw` will be removed entirely in a followup PR along with legacy rotation settings.