### PR TITLE
Sharing wild strikes implementation with feral

### DIFF
--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"time"
-
 	"github.com/wowsims/sod/sim/core/proto"
 	"github.com/wowsims/sod/sim/core/stats"
 )
@@ -182,76 +180,10 @@ func addImbueStats(character *Character, imbue proto.WeaponImbue) {
 				stats.MeleeHit: 2 * MeleeHitRatingPerHitChance,
 			})
 		case proto.WeaponImbue_WildStrikes:
-			buffActionID := ActionID{SpellID: 407975}
-			statDep := character.NewDynamicMultiplyStat(stats.AttackPower, 1.2)
-
-			wsBuffAura := character.GetOrRegisterAura(Aura{
-				Label:     "Wild Strikes Buff",
-				ActionID:  buffActionID,
-				Duration:  time.Millisecond * 1500,
-				MaxStacks: 2,
-				OnGain: func(aura *Aura, sim *Simulation) {
-					aura.Unit.EnableDynamicStatDep(sim, statDep)
-				},
-				OnExpire: func(aura *Aura, sim *Simulation) {
-					aura.Unit.DisableDynamicStatDep(sim, statDep)
-				},
-			})
-
-			var wsSpell *Spell
-			icd := Cooldown{
-				Timer:    character.NewTimer(),
-				Duration: time.Millisecond * 1500,
+			//protect against double application if wild strikes is selected by a feral in sim settings
+			if !character.HasRuneById(int32(proto.DruidRune_RuneChestWildStrikes)) {
+				ApplyWildStrikes(character)
 			}
-
-			MakePermanent(character.GetOrRegisterAura(Aura{
-				Label: "Wild Strikes",
-				OnInit: func(aura *Aura, sim *Simulation) {
-					mhConfig := aura.Unit.AutoAttacks.MHConfig()
-					wsSpell = character.GetOrRegisterSpell(SpellConfig{
-						ActionID:         buffActionID, // temporary buff ("Windfury Attack") spell id
-						SpellSchool:      mhConfig.SpellSchool,
-						ProcMask:         mhConfig.ProcMask,
-						Flags:            mhConfig.Flags,
-						DamageMultiplier: mhConfig.DamageMultiplier,
-						CritMultiplier:   mhConfig.CritMultiplier,
-						ThreatMultiplier: mhConfig.ThreatMultiplier,
-						ApplyEffects:     mhConfig.ApplyEffects,
-					})
-				},
-				OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
-					if spell.ProcMask.Matches(ProcMaskSuppressedExtraAttackAura) {
-						return
-					}
-					if !result.Landed() || !spell.ProcMask.Matches(ProcMaskMelee) {
-						return
-					}
-
-					if wsBuffAura.IsActive() && spell.ProcMask.Matches(ProcMaskMeleeWhiteHit) {
-						wsBuffAura.RemoveStack(sim)
-					}
-
-					if !icd.IsReady(sim) {
-						return
-					}
-
-					if sim.RandomFloat("Wild Strikes") > 0.2 {
-						return
-					}
-
-					wsBuffAura.Activate(sim)
-					wsBuffAura.SetStacks(sim, 2)
-					icd.Use(sim)
-
-					StartDelayedAction(sim, DelayedActionOptions{
-						DoAt:     sim.CurrentTime + time.Millisecond*10,
-						Priority: ActionPriorityAuto,
-						OnAction: func(sim *Simulation) {
-							wsSpell.Cast(sim, result.Target)
-						},
-					})
-				},
-			}))
 		}
 	}
 }

--- a/sim/druid/runes.go
+++ b/sim/druid/runes.go
@@ -13,6 +13,7 @@ func (druid *Druid) ApplyRunes() {
 	druid.applyStarsurge()
 	druid.applyMangle()
 	druid.applySavageRoar()
+	druid.applyWildStrikes()
 }
 
 func (druid *Druid) applyFuryOfStormRage() {
@@ -139,3 +140,12 @@ func (druid *Druid) applyMangle() {
 	druid.applyMangleCat()
 	//druid.applyMangleBear()
 }
+
+func (druid *Druid) applyWildStrikes() {
+	if !druid.HasRune(proto.DruidRune_RuneChestWildStrikes) {
+		return
+	}
+
+	core.ApplyWildStrikes(druid.GetCharacter())
+}
+	

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -11,7 +11,8 @@ import {
 	RaidBuffs,
 	Spec,
 	Stat,
-	TristateEffect,
+        TristateEffect,
+    	WeaponImbue,
 } from '../core/proto/common.js';
 
 import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.js';
@@ -142,7 +143,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		IconInputs.MP5Buff,
 		IconInputs.JudgementOfWisdom,
 	],
-	excludeBuffDebuffInputs: [
+        excludeBuffDebuffInputs: [
+	    WeaponImbue.ElementalSharpeningStone,
+	    WeaponImbue.DenseSharpeningStone,
+	    WeaponImbue.WildStrikes,
 	],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {


### PR DESCRIPTION
Move wild strikes to buffs.go and reuse for feral personal aura
Also hide weapon imbues ferals can't use