### PR TITLE
Added pre-Roar rotation option for Feral sim.

### DIFF
--- a/proto/druid.proto
+++ b/proto/druid.proto
@@ -149,6 +149,7 @@ message FeralDruid {
 	bool maintain_faerie_fire = 1;
 	int32 min_combos_for_rip = 2;
 	float max_wait_time = 3;
+	float preroar_duration = 4;
   }
   Rotation rotation = 1;
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -110,7 +110,7 @@ func (cat *FeralDruid) canRip(sim *core.Simulation) bool {
 	roarDur := cat.SavageRoarAura.RemainingDuration(sim)
 	fightDur := sim.GetRemainingDuration()
 	minRoarCp := min(int32((fightDur-roarDur-time.Second*9)/(time.Second*5))+1, 5)
-	return (cat.timeToCast(minRoarCp+1) < roarDur) && ((cat.ComboPoints() == 5) || (cat.timeToCast(minRoarCp+2) >= roarDur)) && (fightDur > time.Second*10)
+	return !cat.Rip.CurDot().IsActive() && (cat.timeToCast(minRoarCp+1) < roarDur) && ((cat.ComboPoints() == 5) || (cat.timeToCast(minRoarCp+2) >= roarDur)) && (fightDur > time.Second*10)
 }
 
 /*
@@ -198,7 +198,7 @@ func (cat *FeralDruid) shouldPoolMana(sim *core.Simulation, numShiftsToOom int32
 		return true
 	}
 
-	effectiveFightDur := sim.GetRemainingDuration() - core.DurationFromSeconds(1.5) - cat.latency
+	effectiveFightDur := sim.GetRemainingDuration() - core.DurationFromSeconds(3.0) - cat.latency
 	numShiftsToFightEnd := int32(effectiveFightDur / (time.Second * 4))
 	canPoolMana := (numShiftsToOom < cat.maxShifts()) && (numShiftsToOom < numShiftsToFightEnd-1) && (sim.CurrentTime-cat.lastShift > time.Second*5)
 

--- a/sim/druid/savage_roar.go
+++ b/sim/druid/savage_roar.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/wowsims/sod/sim/core"
-	"github.com/wowsims/sod/sim/core/stats"
 	"github.com/wowsims/sod/sim/core/proto"
+	"github.com/wowsims/sod/sim/core/stats"
 )
 
 func (druid *Druid) getSavageRoarMultiplier() float64 {
@@ -23,17 +23,16 @@ func (druid *Druid) applySavageRoar() {
 
 	druid.SavageRoarDurationTable = [6]time.Duration{
 		0,
-		time.Second*(9+5),
-		time.Second*(9+10),
-		time.Second*(9+15),
-		time.Second*(9+20),
-		time.Second*(9+25),
+		time.Second * (9 + 5),
+		time.Second * (9 + 10),
+		time.Second * (9 + 15),
+		time.Second * (9 + 20),
+		time.Second * (9 + 25),
 	}
 
 	druid.SavageRoarAura = druid.RegisterAura(core.Aura{
 		Label:    "Savage Roar Aura",
 		ActionID: actionID,
-		Duration: 9,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			druid.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= srm
 		},
@@ -41,6 +40,9 @@ func (druid *Druid) applySavageRoar() {
 			if druid.InForm(Cat) {
 				druid.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] /= srm
 			}
+		},
+		OnReset: func(aura *core.Aura, sim *core.Simulation) {
+			aura.Duration = druid.SavageRoarDurationTable[5] // for pre-pull
 		},
 	})
 
@@ -73,4 +75,3 @@ func (druid *Druid) applySavageRoar() {
 func (druid *Druid) CurrentSavageRoarCost() float64 {
 	return druid.SavageRoar.ApplyCostModifiers(druid.SavageRoar.DefaultCast.Cost)
 }
-

--- a/ui/feral_druid/apls/default.apl.json
+++ b/ui/feral_druid/apls/default.apl.json
@@ -1,8 +1,9 @@
 {
    "type": "TypeAPL",
       "prepullActions": [
+	{"action":{"activateAura":{"auraId":{"spellId":407988}}},"doAtValue":{"const":{"val":"-8s"}}}
       ],
       "priorityList": [
-        {"action":{"catOptimalRotationAction":{"maxWaitTime":1.5,"minCombosForRip":3}}}
+        {"action":{"catOptimalRotationAction":{"maxWaitTime":2,"minCombosForRip":3}}}
       ]
 }

--- a/ui/feral_druid/inputs.ts
+++ b/ui/feral_druid/inputs.ts
@@ -54,5 +54,12 @@ export const FeralDruidRotationConfig = {
 			float: true,
 			positive: true,
 		}),
+		InputHelpers.makeRotationNumberInput<Spec.SpecFeralDruid>({
+			fieldName: 'preroarDuration',
+			label: 'Pre-Roar Duration',
+			labelTooltip: 'Seconds remaining on a prior Savage Roar buff at the start of the pull.',
+			float: true,
+			positive: true,
+		}),
 	],
 };

--- a/ui/feral_druid/presets.ts
+++ b/ui/feral_druid/presets.ts
@@ -32,7 +32,8 @@ export const APL_ROTATION_DEFAULT = PresetUtils.makePresetAPLRotation('APL Defau
 export const DefaultRotation = FeralDruidRotation.create({
 	maintainFaerieFire: false,
 	minCombosForRip: 3,
-	maxWaitTime: 1.5,
+	maxWaitTime: 2.0,
+	preroarDuration: 26.0,
 });
 
 export const SIMPLE_ROTATION_DEFAULT = PresetUtils.makePresetSimpleRotation('Simple Default', Spec.SpecFeralDruid, DefaultRotation);

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -186,7 +186,13 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	simpleRotation: (player: Player<Spec.SpecFeralDruid>, simple: DruidRotation, cooldowns: Cooldowns): APLRotation => {
 		let [prepullActions, actions] = AplUtils.standardCooldownDefaults(cooldowns);
 
+		const preroarDuration = Math.min(simple.preroarDuration, 33.0);
+		const preRoar = APLPrepullAction.fromJsonString(`{"action":{"activateAura":{"auraId":{"spellId":407988}}},"doAtValue":{"const":{"val":"-${(34.0 - preroarDuration).toFixed(2)}s"}}}`);
 		const doRotation = APLAction.fromJsonString(`{"catOptimalRotationAction":{"maxWaitTime":${simple.maxWaitTime.toFixed(2)},"minCombosForRip":${simple.minCombosForRip.toFixed(0)}}}`);
+
+		prepullActions.push(...[
+			preroarDuration > 0 ? preRoar: null,
+		].filter(a => a) as Array<APLPrepullAction>)
 
 		actions.push(...[
 			doRotation,


### PR DESCRIPTION
 On branch sod-fork

 Changes to be committed:
	modified:   proto/druid.proto
	modified:   sim/druid/feral/rotation.go
	modified:   sim/druid/savage_roar.go
	modified:   ui/feral_druid/apls/default.apl.json
	modified:   ui/feral_druid/inputs.ts
	modified:   ui/feral_druid/presets.ts
	modified:   ui/feral_druid/sim.ts