### PR TITLE
SoD fork: Fix IconEnumPicker on level change

### DIFF
--- a/ui/core/components/icon_enum_picker.tsx
+++ b/ui/core/components/icon_enum_picker.tsx
@@ -125,6 +125,7 @@ export class IconEnumPicker<ModObject, T> extends Input<ModObject, T> {
 							if (this.storedValue == valueConfig.value) {
 								this.restoreValue();
 							}
+							this.setImage(option, valueConfig);
 						}
 					} else if (isShown) {
 						if (this.getInputValue() == valueConfig.value){

--- a/ui/core/components/icon_enum_picker.tsx
+++ b/ui/core/components/icon_enum_picker.tsx
@@ -118,10 +118,15 @@ export class IconEnumPicker<ModObject, T> extends Input<ModObject, T> {
 			if (valueConfig.showWhen) {
 				config.changedEvent(this.modObject).on(_ => {
 					const show = valueConfig.showWhen && valueConfig.showWhen(this.modObject);
-					if (show){
-						optionContainer.classList.remove('hide');
-						this.restoreValue();
-					} else {
+					const isShown = !optionContainer.classList.contains('hide');
+					if (show) {
+						if (!isShown) {
+							optionContainer.classList.remove('hide');
+							if (this.storedValue == valueConfig.value) {
+								this.restoreValue();
+							}
+						}
+					} else if (isShown) {
 						if (this.getInputValue() == valueConfig.value){
 							this.storeValue();
 						}


### PR DESCRIPTION
The (re)storeValue() calls on level change events cause a lot of recursion due to occurring on and causing a changedEvent. To confirm this problem for yourself go into the feral sim, set level to e.g. 40 and agility elixir to Greater Agility, then set level to 25. Process will freeze some time.

This changes the calls to (re)storeValue() to only happen if the respective option becomes (in)visible and the currently stored value is actually the option value. This results in only one extra event and one extra setInputValue() call after the level change event.

Additionally background images for options in the picker are currently never loaded if they have a level condition > 25 because the default level on initial load is 25. This also adds a setImage() once they become visible.

Not a particularly clean solution, but not sure if it can be solved without some bigger alterations to how the UI works or getting rid of the whole restore functionality.