### PR TITLE
More Level 25 UI tweaks for consumes and buffs.

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -295,6 +295,7 @@ enum AgilityElixir {
 	ElixirOfTheMongoose = 1;
 	ElixirOfGreaterAgility = 2;
 	ElixirOfLesserAgility = 3;
+	ScrollOfAgility = 4;
 }
 
 enum ManaRegenElixir {
@@ -307,6 +308,7 @@ enum StrengthBuff {
 	JujuPower = 1;
 	ElixirOfGiants = 2;
 	ElixirOfOgresStrength = 3;
+	ScrollOfStrength = 4;
 }
 
 enum AttackPowerBuff {
@@ -359,6 +361,7 @@ enum Food {
 	FoodBlessSunfruit = 7;
 	FoodHotWolfRibs = 8;
 	FoodTenderWolfSteak = 9;
+	FoodSmokedSagefish = 10;
 }
 
 enum SaygesFortune {
@@ -431,6 +434,7 @@ message RaidBuffs {
 
 	// SoD Runes
 	int32 demonic_pact = 32;
+	bool horn_of_lordaeron = 33;
 }
 
 // Buffs that affect a single party.

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -26,6 +26,7 @@ const (
 	PowerWordFortitude
 	StrengthOfEarth
 	TrueshotAura
+	HornOfLordaeron
 
 	// Resistance
 	AspectOfTheWild
@@ -170,6 +171,24 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 		},
 		60: stats.Stats{
 			stats.Stamina: 60,
+		},
+	},
+	HornOfLordaeron: {
+		25: stats.Stats{
+			stats.Strength: 17,
+			stats.Agility:  17,
+		},
+		40: stats.Stats{
+			stats.Strength: 26,
+			stats.Agility:  26,
+		},
+		50: stats.Stats{
+			stats.Strength: 45,
+			stats.Agility:  45,
+		},
+		60: stats.Stats{
+			stats.Strength: 89,
+			stats.Agility:  89,
 		},
 	},
 	ManaSpring: {
@@ -504,7 +523,10 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 	if raidBuffs.BattleShout != proto.TristateEffect_TristateEffectMissing {
 		MakePermanent(BattleShoutAura(&character.Unit, GetTristateValueInt32(raidBuffs.BattleShout, 0, 5), 0, level))
 	}
-	if individualBuffs.BlessingOfMight != proto.TristateEffect_TristateEffectMissing {
+
+	if raidBuffs.HornOfLordaeron {
+		character.AddStats(BuffSpellByLevel[HornOfLordaeron][level])
+	} else if individualBuffs.BlessingOfMight != proto.TristateEffect_TristateEffectMissing {
 		MakePermanent(BlessingOfMightAura(&character.Unit, GetTristateValueInt32(individualBuffs.BlessingOfMight, 0, 5), level))
 	}
 

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -50,6 +50,15 @@ func applyConsumeEffects(agent Agent) {
 
 	if consumes.Food != proto.Food_FoodUnknown {
 		switch consumes.Food {
+		case proto.Food_FoodHotWolfRibs:
+			character.AddStats(stats.Stats{
+				stats.Stamina: 8,
+				stats.Spirit:  8,
+			})
+		case proto.Food_FoodSmokedSagefish:
+			character.AddStats(stats.Stats{
+				stats.MP5: 3,
+			})
 		case proto.Food_FoodGrilledSquid:
 			character.AddStats(stats.Stats{
 				stats.Agility: 10,
@@ -96,6 +105,8 @@ func applyConsumeEffects(agent Agent) {
 			character.AddStats(stats.Stats{
 				stats.Agility: 8,
 			})
+		case proto.AgilityElixir_ScrollOfAgility:
+			character.AddStats(BuffSpellByLevel[ScrollOfAgility][character.Level])
 		}
 	}
 
@@ -113,6 +124,8 @@ func applyConsumeEffects(agent Agent) {
 			character.AddStats(stats.Stats{
 				stats.Strength: 8,
 			})
+		case proto.StrengthBuff_ScrollOfStrength:
+			character.AddStats(BuffSpellByLevel[ScrollOfStrength][character.Level])
 		}
 	}
 

--- a/ui/core/components/icon_inputs.ts
+++ b/ui/core/components/icon_inputs.ts
@@ -74,12 +74,12 @@ export const StaminaBuff = InputHelpers.makeMultiIconInput([
 
 export const StrengthRaidBuff = InputHelpers.makeMultiIconInput([
 	makeTristateRaidBuffInput({id: ActionId.fromSpellId(25361), impId: ActionId.fromSpellId(16295), fieldName: 'strengthOfEarthTotem'}),
-	makeBooleanRaidBuffInput({id: ActionId.fromItemId(10310), fieldName: 'scrollOfStrength'}),
+	makeBooleanRaidBuffInput({id: ActionId.fromSpellId(425600), fieldName: 'hornOfLordaeron'}),
 ], 'Str');
 
 export const AgilityRaidBuff = InputHelpers.makeMultiIconInput([
 	makeTristateRaidBuffInput({id: ActionId.fromSpellId(25359), impId: ActionId.fromSpellId(16295), fieldName: 'graceOfAirTotem', minLevel: 42}),
-	makeBooleanRaidBuffInput({id: ActionId.fromItemId(10309), fieldName: 'scrollOfAgility'}),
+	makeBooleanRaidBuffInput({id: ActionId.fromSpellId(425600), fieldName: 'hornOfLordaeron'}),
 ], 'Agi');
 
 export const IntellectBuff = InputHelpers.makeMultiIconInput([
@@ -439,7 +439,7 @@ export const makeConjuredInput = makeConsumeInputFactory({
 	consumesFieldName: 'defaultConjured',
 	allOptions: [
 		{ actionId: ActionId.fromItemId(4381), value: Conjured.ConjuredMinorRecombobulator, showWhen: (player: Player<any>) => player.getGear().hasTrinket(4381) },
-		{ actionId: ActionId.fromItemId(12662), value: Conjured.ConjuredDemonicRune },
+		{ actionId: ActionId.fromItemId(12662), value: Conjured.ConjuredDemonicRune, showWhen: (p) => p.getLevel() >= 40 },
 	] as Array<IconEnumValueConfig<Player<any>, Conjured>>
 });
 
@@ -486,9 +486,9 @@ export const makeOffHandImbuesInput = makeConsumeInputFactory({
 export const makeFoodInput = makeConsumeInputFactory({
 	consumesFieldName: 'food',
 	allOptions: [
-		{ actionId: ActionId.fromItemId(15856), value: Food.FoodHotWolfRibs, showWhen: (p) => p.getLevel() >= 25 },
+		{ actionId: ActionId.fromItemId(21072), value: Food.FoodSmokedSagefish, showWhen: (p) => p.getLevel() >= 10 },
+		{ actionId: ActionId.fromItemId(13851), value: Food.FoodHotWolfRibs, showWhen: (p) => p.getLevel() >= 25 },
 		{ actionId: ActionId.fromItemId(22480), value: Food.FoodTenderWolfSteak, showWhen: (p) => p.getLevel() >= 40 },
-		{ actionId: ActionId.fromItemId(13931), value: Food.FoodNightfinSoup, showWhen: (p) => p.getLevel() >= 35 },
 		{ actionId: ActionId.fromItemId(13931), value: Food.FoodNightfinSoup, showWhen: (p) => p.getLevel() >= 35 },
 		{ actionId: ActionId.fromItemId(13928), value: Food.FoodGrilledSquid, showWhen: (p) => p.getLevel() >= 35 },
 		{ actionId: ActionId.fromItemId(20452), value: Food.FoodSmokedDesertDumpling, showWhen: (p) => p.getLevel() >= 45 },
@@ -503,12 +503,14 @@ export const AgilityBuffInput = makeConsumeInput('agilityElixir', [
 	{ actionId: ActionId.fromItemId(13452), value: AgilityElixir.ElixirOfTheMongoose, showWhen: (p) => p.getLevel() >= 46 },
 	{ actionId: ActionId.fromItemId(9187), value: AgilityElixir.ElixirOfGreaterAgility, showWhen: (p) => p.getLevel() >= 38},
         { actionId: ActionId.fromItemId(3390), value: AgilityElixir.ElixirOfLesserAgility, showWhen: (p) => p.getLevel() >= 18},
+	{ actionId: ActionId.fromItemId(10309), value: AgilityElixir.ScrollOfAgility},
 ] as Array<IconEnumValueConfig<Player<any>, AgilityElixir>>, (p) => p.getLevel() >= 18);
 
 export const StrengthBuffInput = makeConsumeInput('strengthBuff', [
 	{ actionId: ActionId.fromItemId(12451), value: StrengthBuff.JujuPower, showWhen: (p) => p.getLevel() >= 46 },
 	{ actionId: ActionId.fromItemId(9206), value: StrengthBuff.ElixirOfGiants, showWhen: (p) => p.getLevel() >= 46 },
         { actionId: ActionId.fromItemId(3391), value: StrengthBuff.ElixirOfOgresStrength, showWhen: (p) => p.getLevel() >= 20},
+	{ actionId: ActionId.fromItemId(10310), value: StrengthBuff.ScrollOfStrength },
 ] as Array<IconEnumValueConfig<Player<any>, StrengthBuff>>, (p) => p.getLevel() >= 20);
 
 export const SpellDamageBuff = makeConsumeInput('spellPowerBuff', [

--- a/ui/core/components/individual_sim_ui/consumes_picker.ts
+++ b/ui/core/components/individual_sim_ui/consumes_picker.ts
@@ -160,6 +160,8 @@ export class ConsumesPicker extends Component {
 		this.rootElem.appendChild(fragment.children[0] as HTMLElement);
 
 		const foodOptions = this.simUI.splitRelevantOptions([
+			{ item: Food.FoodHotWolfRibs, stats: [Stat.StatSpirit] },
+			{ item: Food.FoodSmokedSagefish, stats: [Stat.StatMP5] },
 			{ item: Food.FoodNightfinSoup, stats: [Stat.StatMP5, Stat.StatSpellPower] },
 			{ item: Food.FoodGrilledSquid, stats: [Stat.StatAgility] },
 			{ item: Food.FoodSmokedDesertDumpling, stats: [Stat.StatStrength] },
@@ -200,12 +202,14 @@ export class ConsumesPicker extends Component {
 	}
 
 	private buildSpellPowerBuffPicker() {
-		const includeSpellPower = !this.simUI.individualConfig.excludeBuffDebuffInputs.includes(IconInputs.SpellDamageBuff);
-		const includeShadowPower = !this.simUI.individualConfig.excludeBuffDebuffInputs.includes(IconInputs.ShadowDamageBuff);
-		const includeFirePower = !this.simUI.individualConfig.excludeBuffDebuffInputs.includes(IconInputs.FireDamageBuff);
-		const includeFrostPower = !this.simUI.individualConfig.excludeBuffDebuffInputs.includes(IconInputs.FrostDamageBuff);
+		const config = this.simUI.individualConfig;
+		const includeSpellPower = config.epStats.includes(Stat.StatSpellPower) && !config.excludeBuffDebuffInputs.includes(IconInputs.SpellDamageBuff);
 
-		if (!includeSpellPower && !includeShadowPower && !includeFirePower && !includeFrostPower) return;
+		if (!includeSpellPower) return;
+
+		const includeShadowPower = !config.excludeBuffDebuffInputs.includes(IconInputs.ShadowDamageBuff);
+		const includeFirePower = !config.excludeBuffDebuffInputs.includes(IconInputs.FireDamageBuff);
+		const includeFrostPower = !config.excludeBuffDebuffInputs.includes(IconInputs.FrostDamageBuff);
 
 		let fragment = document.createElement('fragment');
 		fragment.innerHTML = `

--- a/ui/feral_druid/presets.ts
+++ b/ui/feral_druid/presets.ts
@@ -5,7 +5,10 @@ import {
 	Profession,
 	Spec,
 	Potions,
-	Conjured
+	Conjured,
+	WeaponImbue,
+	AgilityElixir,
+	StrengthBuff
 } from '../core/proto/common.js';
 import { SavedTalents } from '../core/proto/ui.js';
 
@@ -54,9 +57,12 @@ export const DefaultOptions = FeralDruidOptions.create({
 
 export const DefaultConsumes = Consumes.create({
 	flask: Flask.FlaskUnknown,
-	food: Food.FoodUnknown,
+	food: Food.FoodSmokedSagefish,
 	defaultPotion: Potions.ManaPotion,
 	defaultConjured: Conjured.ConjuredMinorRecombobulator,
+	mainHandImbue: WeaponImbue.BlackfathomSharpeningStone,
+	agilityElixir: AgilityElixir.ElixirOfLesserAgility,
+	strengthBuff: StrengthBuff.ElixirOfOgresStrength,
 });
 
 export const OtherDefaults = {

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -57,8 +57,9 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
 		Stat.StatArmorPenetration,
-		Stat.StatExpertise,
 		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatMP5,
 	],
 	epPseudoStats: [
 		PseudoStat.PseudoStatMainHandDps,
@@ -74,9 +75,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
-		Stat.StatExpertise,
 		Stat.StatMana,
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatMP5,
 	],
 
 	defaults: {
@@ -106,28 +108,25 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		// Default raid/party buffs settings.
 		raidBuffs: RaidBuffs.create({
 			arcaneBrilliance: true,
-			giftOfTheWild: TristateEffect.TristateEffectImproved,
-			manaSpringTotem: TristateEffect.TristateEffectRegular,
-			strengthOfEarthTotem: TristateEffect.TristateEffectRegular,
-			battleShout: TristateEffect.TristateEffectImproved,
+			giftOfTheWild: TristateEffect.TristateEffectRegular,
+			battleShout: TristateEffect.TristateEffectRegular,
 		}),
 
-		partyBuffs: PartyBuffs.create({
-			heroicPresence: true,
-		}),
+		partyBuffs: PartyBuffs.create({}),
 
 		individualBuffs: IndividualBuffs.create({
-			blessingOfKings: true,
+			aspectOfTheLion: true,
 			blessingOfMight: TristateEffect.TristateEffectImproved,
 		}),
 
 		debuffs: Debuffs.create({
 			judgementOfWisdom: true,
 			giftOfArthas: true,
-			exposeArmor: TristateEffect.TristateEffectImproved,
-			faerieFire: true,
-			sunderArmor: true,
-			curseOfWeakness: TristateEffect.TristateEffectRegular,
+			exposeArmor: TristateEffect.TristateEffectMissing,
+			faerieFire: false,
+			sunderArmor: false,
+			curseOfRecklessness: false,
+			homunculi: true,
 		}),
 
 		other: Presets.OtherDefaults,
@@ -153,7 +152,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	otherInputs: {
 		inputs: [
 			DruidInputs.LatencyMs,
-			DruidInputs.AssumeBleedActive,
+			// DruidInputs.AssumeBleedActive,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,
 		],


### PR DESCRIPTION
 On branch sod-fork

 Changes to be committed:
	modified:   proto/common.proto
	modified:   sim/core/buffs.go
	modified:   sim/core/consumes.go
	modified:   ui/core/components/icon_inputs.ts
	modified:   ui/core/components/individual_sim_ui/consumes_picker.ts
	modified:   ui/feral_druid/presets.ts
	modified:   ui/feral_druid/sim.ts