### PR TITLE
SoD: Use correct spirit mana regen formula

### DIFF
--- a/sim/core/mana.go
+++ b/sim/core/mana.go
@@ -156,8 +156,10 @@ func (unit *Unit) MP5ManaRegenPerSecond() float64 {
 }
 
 // Returns the rate of mana regen per second from spirit.
+// All classes except Priest and Mage use this.
 func (unit *Unit) SpiritManaRegenPerSecondDefault() float64 {
-	return 15.001 + unit.stats[stats.Spirit]/15
+	// 15 + Spirit/5 every 2s tick
+	return 7.5 + unit.stats[stats.Spirit]/10
 }
 
 // Returns the rate of mana regen per second, assuming this unit is

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -3,6 +3,7 @@ package mage
 import (
 	"github.com/wowsims/sod/sim/core"
 	"github.com/wowsims/sod/sim/core/proto"
+	"github.com/wowsims/sod/sim/core/stats"
 )
 
 const (
@@ -114,6 +115,11 @@ func NewMage(character *core.Character, options *proto.Player) *Mage {
 
 	if mage.Options.Armor == proto.Mage_Options_MageArmor {
 		mage.PseudoStats.SpiritRegenRateCasting += .3
+	}
+
+	// Set mana regen to 12.5 + Spirit/4 each 2s tick
+	mage.SpiritManaRegenPerSecond = func() float64 {
+		return 6.25 + mage.GetStat(stats.Spirit)/8
 	}
 
 	return mage

--- a/sim/priest/priest.go
+++ b/sim/priest/priest.go
@@ -3,6 +3,7 @@ package priest
 import (
 	"github.com/wowsims/sod/sim/core"
 	"github.com/wowsims/sod/sim/core/proto"
+	"github.com/wowsims/sod/sim/core/stats"
 )
 
 var TalentTreeSizes = [3]int{15, 16, 16}
@@ -111,6 +112,11 @@ func New(char *core.Character, talents string) *Priest {
 	core.FillTalentsProto(priest.Talents.ProtoReflect(), talents, TalentTreeSizes)
 
 	priest.EnableManaBar()
+
+	// Set mana regen to 12.5 + Spirit/4 each 2s tick
+	priest.SpiritManaRegenPerSecond = func() float64 {
+		return 6.25 + priest.GetStat(stats.Spirit)/8
+	}
 
 	return priest
 }


### PR DESCRIPTION
Current spirit formula is very wrong and used for all classes. This sets the formulas to:

`15 + Spirit/5` every 2s tick as the default in mana.go.
`12.5 + Spirit/4` every 2s tick for Priest and Mage in their respective class file.

The default formula was tested on a Druid and a Warlock at different spirit levels. The Priest and Mage one was tested on those classes. In all cases it fit perfectly with ingame values gotten via GetManaRegen(). Notably WL seems to use the default formula and not a different one as some sources claim.

Untested on Hunter, Shaman and Paladin, but there's no information that would hint to them using anything else.

**Note if someone wants to test this:** Low level characters use different formulas! Every class starts with simply spirit/2 as mana regen. I don't know at which level it (fully) becomes the actual formula, only that by lvl 25 it definitely is. If I had to guess I'd say level 20 based on how it was later on.