### PR TITLE
Fix feral code references to rotation before it is set

### DIFF
--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -41,8 +41,6 @@ func NewFeralDruid(character *core.Character, options *proto.Player) *FeralDruid
 
 	cat.AssumeBleedActive = feralOptions.Options.AssumeBleedActive
 	cat.maxRipTicks = cat.MaxRipTicks()
-	cat.prepopOoc = feralOptions.Rotation.PrePopOoc
-	cat.setupRotation(feralOptions.Rotation)
 
 	cat.EnableEnergyBar(100.0)
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -695,6 +695,7 @@ func (cat *FeralDruid) setupRotation(rotation *proto.FeralDruid_Rotation) {
 		AoeMangleBuilder: equipedIdol == 45509 || equipedIdol == 47668,
 		RakeDpeCheck:     equipedIdol != 50456,
 	}
+	cat.prepopOoc = rotation.PrePopOoc
 
 	// Use automatic values unless specified
 	if rotation.ManualParams {


### PR DESCRIPTION
Fixes #4163, #4164, #4165, #4166, #4167, #4169, #4170