### PR TITLE
Fixed base Spirit value for Druids at level 25

### DIFF
--- a/sim/core/base_stats.go
+++ b/sim/core/base_stats.go
@@ -437,7 +437,7 @@ var ClassBaseStats = map[proto.Class]map[int]stats.Stats{
 			stats.Agility:     34,
 			stats.Strength:    36,
 			stats.Intellect:   47,
-			stats.Spirit:      0,
+			stats.Spirit:      50,
 			stats.Stamina:     35,
 			stats.AttackPower: -20,
 		},


### PR DESCRIPTION
 On branch sod-fork

 Changes to be committed:
	modified:   sim/core/base_stats.go