### PR TITLE
Added Bogling Root consume option

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -495,6 +495,7 @@ message Consumes {
 	WeaponImbue off_hand_imbue = 16;
 	Potions default_potion = 17;
 	Conjured default_conjured = 18;
+	bool bogling_root = 19;
 }
 
 message Debuffs {

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -129,6 +129,10 @@ func applyConsumeEffects(agent Agent) {
 		}
 	}
 
+	if consumes.BoglingRoot {
+		character.PseudoStats.BonusDamage += 1
+	}
+
 	if consumes.SpellPowerBuff != proto.SpellPowerBuff_SpellPowerBuffUnknown {
 		switch consumes.SpellPowerBuff {
 		case proto.SpellPowerBuff_ArcaneElixir:

--- a/ui/core/components/icon_inputs.ts
+++ b/ui/core/components/icon_inputs.ts
@@ -523,6 +523,8 @@ export const StrengthBuffInput = makeConsumeInput('strengthBuff', [
 	{ actionId: ActionId.fromItemId(10310), value: StrengthBuff.ScrollOfStrength },
 ] as Array<IconEnumValueConfig<Player<any>, StrengthBuff>>, (p) => p.getLevel() >= 20);
 
+export const BoglingRootInput = makeBooleanConsumeInput({id: ActionId.fromItemId(5206), fieldName: 'boglingRoot' });
+
 export const SpellDamageBuff = makeConsumeInput('spellPowerBuff', [
 	{ actionId: ActionId.fromItemId(9155), value: SpellPowerBuff.ArcaneElixir, showWhen: (p) => p.getLevel() >= 37 },
 	{ actionId: ActionId.fromItemId(13454), value: SpellPowerBuff.GreaterArcaneElixir, showWhen: (p) => p.getLevel() >= 46 },

--- a/ui/core/components/individual_sim_ui/consumes_picker.ts
+++ b/ui/core/components/individual_sim_ui/consumes_picker.ts
@@ -199,6 +199,8 @@ export class ConsumesPicker extends Component {
 		if (includeStr){
 			buildIconInput(physicalConsumesElem, this.simUI.player, IconInputs.StrengthBuffInput);
 		}
+
+		buildIconInput(physicalConsumesElem, this.simUI.player, IconInputs.BoglingRootInput);
 	}
 
 	private buildSpellPowerBuffPicker() {

--- a/ui/feral_druid/presets.ts
+++ b/ui/feral_druid/presets.ts
@@ -63,6 +63,7 @@ export const DefaultConsumes = Consumes.create({
 	mainHandImbue: WeaponImbue.BlackfathomSharpeningStone,
 	agilityElixir: AgilityElixir.ElixirOfLesserAgility,
 	strengthBuff: StrengthBuff.ElixirOfOgresStrength,
+	boglingRoot: true,
 });
 
 export const OtherDefaults = {


### PR DESCRIPTION
 On branch sod-fork

 Changes to be committed:
	modified:   proto/common.proto
	modified:   sim/core/consumes.go
	modified:   ui/core/components/icon_inputs.ts
	modified:   ui/core/components/individual_sim_ui/consumes_picker.ts
	modified:   ui/feral_druid/presets.ts