### PR TITLE
SoD Feral Druid: Expand usage of Rip

### DIFF
--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -116,13 +116,18 @@ func (cat *FeralDruid) canRip(sim *core.Simulation, isTrick bool) bool {
 		return false
 	}
 
-	// Don't rip if it won't be able to tick for the full duration.
-	if fightDur <= time.Second*10 {
-		return false
-	}
-
 	if cat.ComboPoints() == 5 {
-		return true
+		// 5CP rip is worth it with 4 ticks
+		if fightDur <= time.Second*8 {
+			return false
+		} else {
+			return true
+		}
+	} else {
+		// Otherwise require 5 ticks
+		if fightDur <= time.Second*10 {
+			return false
+		}
 	}
 
 	// If we can't get any more combo points before roar expires, then we should rip now.

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -268,10 +268,10 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 		nextAbility = cat.SavageRoar
 	} else if isClearcast {
 		nextAbility = cat.Shred
-	} else if curCp >= 1 && cat.clipRoar(sim) {
-		nextAbility = cat.SavageRoar
 	} else if (curCp >= rotation.MinCombosForRip || canRipTrick) && cat.canRip(sim, canRipTrick) {
 		nextAbility = cat.Rip
+	} else if curCp >= 1 && cat.clipRoar(sim) {
+		nextAbility = cat.SavageRoar
 	} else if canShredTrick {
 		nextAbility = cat.Shred
 	} else {


### PR DESCRIPTION
First commit (bec24133aaad6a62bae68c7ef0b091abe5c37268) in this PR has no functional changes, just makes Rip a bit easier to reason about and sets up for the 3rd commit.
2nd commit (f646038dff611877422cfb3ec44beabe60cc5048) prefers Rip before ClipRoar in rotation.
3rd commit (f1447aad20fbb0d3d5ccb07ab3cdf3e8d5abda17) allows 5CP rip with only 8 seconds left in the fights.

2nd and 3rd commits cumulatively increase DPS. I ran 1 million iterations sims using the default config / rotation, sweeping from 30 to 180 seconds durations.

| Duration (s) | Baseline DPS | f646038dff611877422cfb3ec44beabe60cc5048 DPS | f1447aad20fbb0d3d5ccb07ab3cdf3e8d5abda17 DPS |
| --- | --- | --- | --- |
| 30 | 316.78 | 316.89 | 317.38 |
| 40 | 317.23 | 318.24 | 318.68 |
| 50 | 313.48 | 313.56 | 313.64 |
| 60 | 303.05 | 303.55 | 303.67 |
| 70 | 295.35 | 296.30 | 296.57 |
| 80 | 293.95 | 294.27 | 294.42 |
| 90 | 290.35 | 290.47 | 290.56 |
| 100 | 284.12 | 286.14 | 286.26 |
| 110 | 283.22 | 284.59 | 284.71 |
| 120 | 282.35 | 282.39 | 282.47 |
| 130 | 278.62 | 280.26 | 280.37 |
| 140 | 276.91 | 279.10 | 279.24 |
| 150 | 278.13 | 278.35 | 278.41 |
| 160 | 277.40 | 278.15 | 278.24 |
| 170 | 275.99 | 278.10 | 278.19 |
| 180 | 277.07 | 277.87 | 277.93 |

Other notes:
This still allows 3CP rip with 10 seconds remaining. I tried requiring 12 seconds duration for 3CP rip but it it did not make any measurable difference.

The baseline exhibits some instability between durations (140 and 170 had oddly low DPS), which is now resolved; DPS should always decrease as duration increases.