### PR TITLE
Allow simple rotations as defaults

### DIFF
--- a/ui/balance_druid/sim.ts
+++ b/ui/balance_druid/sim.ts
@@ -66,7 +66,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.BalanceTalents.data,
 		// Default spec-specific settings.

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -1396,12 +1396,6 @@ export class Player<SpecType extends Spec> {
 				hpPercentForDefensives: isTankSpec(this.spec) ? 0.35 : 0,
 			}));
 			this.setBonusStats(eventID, new Stats());
-
-			if (aplLaunchStatuses[this.spec] >= LaunchStatus.Beta) {
-				this.setAplRotation(eventID, APLRotation.create({
-					type: APLRotationType.TypeAuto,
-				}))
-			}
 		});
 	}
 }

--- a/ui/elemental_shaman/sim.ts
+++ b/ui/elemental_shaman/sim.ts
@@ -95,7 +95,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecElementalShaman, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.StandardTalents.data,
 		// Default spec-specific settings.

--- a/ui/enhancement_shaman/sim.ts
+++ b/ui/enhancement_shaman/sim.ts
@@ -98,7 +98,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.StandardTalents.data,
 		// Default spec-specific settings.

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -38,6 +38,7 @@ import {
 	APLPrepullAction,
 	APLListItem,
 	APLRotation,
+	APLRotation_Type as APLRotationType,
 } from '../core/proto/apl.js';
 
 const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
@@ -104,7 +105,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		rotationType: APLRotationType.TypeSimple,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.StandardTalents.data,
 		// Default spec-specific settings.

--- a/ui/feral_tank_druid/sim.ts
+++ b/ui/feral_tank_druid/sim.ts
@@ -104,7 +104,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralTankDruid, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.StandardTalents.data,
 		// Default spec-specific settings.

--- a/ui/healing_priest/sim.ts
+++ b/ui/healing_priest/sim.ts
@@ -65,7 +65,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHealingPriest, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DiscDefaultRotation,
+		simpleRotation: Presets.DiscDefaultRotation,
 		// Default talents.
 		talents: Presets.DiscTalents.data,
 		// Default spec-specific settings.

--- a/ui/holy_paladin/sim.ts
+++ b/ui/holy_paladin/sim.ts
@@ -67,7 +67,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHolyPaladin, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.StandardTalents.data,
 		// Default spec-specific settings.

--- a/ui/hunter/sim.ts
+++ b/ui/hunter/sim.ts
@@ -118,7 +118,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.SurvivalTalents.data,
 		// Default spec-specific settings.

--- a/ui/protection_paladin/sim.ts
+++ b/ui/protection_paladin/sim.ts
@@ -114,7 +114,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.GenericAoeTalents.data,
 		// Default spec-specific settings.

--- a/ui/protection_warrior/sim.ts
+++ b/ui/protection_warrior/sim.ts
@@ -111,7 +111,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.StandardTalents.data,
 		// Default spec-specific settings.

--- a/ui/restoration_druid/sim.ts
+++ b/ui/restoration_druid/sim.ts
@@ -63,7 +63,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationDruid, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.CelestialFocusTalents.data,
 		// Default spec-specific settings.

--- a/ui/restoration_shaman/sim.ts
+++ b/ui/restoration_shaman/sim.ts
@@ -79,7 +79,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationShaman, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.RaidHealingTalents.data,
 		// Default spec-specific settings.

--- a/ui/retribution_paladin/sim.ts
+++ b/ui/retribution_paladin/sim.ts
@@ -96,7 +96,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.AuraMasteryTalents.data,
 		// Default spec-specific settings.

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -198,7 +198,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default rotation settings.
-		rotation: Presets.DefaultRotation,
+		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
 		talents: Presets.AssassinationTalents137.data,
 		// Default spec-specific settings.


### PR DESCRIPTION
Allows specification of simple rather than auto rotations as the default interface if desired for a particular sim.

 On branch sod-fork

 Changes to be committed:
	modified:   ui/balance_druid/sim.ts
	modified:   ui/core/individual_sim_ui.ts
	modified:   ui/core/player.ts
	modified:   ui/elemental_shaman/sim.ts
	modified:   ui/enhancement_shaman/sim.ts
	modified:   ui/feral_druid/sim.ts
	modified:   ui/feral_tank_druid/sim.ts
	modified:   ui/healing_priest/sim.ts
	modified:   ui/holy_paladin/sim.ts
	modified:   ui/hunter/sim.ts
	modified:   ui/protection_paladin/sim.ts
	modified:   ui/protection_warrior/sim.ts
	modified:   ui/restoration_druid/sim.ts
	modified:   ui/restoration_shaman/sim.ts
	modified:   ui/retribution_paladin/sim.ts
	modified:   ui/rogue/sim.ts