### PR TITLE
WIP: Sim talents in bulk sim

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -431,6 +431,12 @@ message BulkSimRequest {
     BulkSettings bulk_settings = 2;
 }
 
+message TalentLoadout {
+	string talents_string = 1;
+	Glyphs glyphs = 2;
+	string name = 3;
+}
+
 message BulkSettings {
 	repeated ItemSpec items = 1;
 	bool combinations = 2;
@@ -451,6 +457,9 @@ message BulkSettings {
 	// Number of iterations per combo.
 	// If set to 0 the sim core decides the optimal iterations.
 	int32 iterations_per_combo = 11;
+	// Should sim talents as well
+	bool sim_talents = 12;
+	repeated TalentLoadout talents_to_sim = 13;
 }
 
 message BulkSimResult {
@@ -462,6 +471,7 @@ message BulkSimResult {
 message BulkComboResult {
     repeated ItemSpecWithSlot items_added = 1;
     UnitMetrics unit_metrics = 2;
+	TalentLoadout talent_loadout = 3;
 }
 
 message ItemSpecWithSlot {

--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -197,6 +198,10 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 					for _, talent := range talentsToSim {
 						sr := goproto.Clone(substitutedRequest).(*proto.RaidSimRequest)
 						cl := *changeLog
+						if sr.Raid.Parties[0].Players[0].TalentsString == talent.TalentsString && reflect.DeepEqual(talent.Glyphs, sr.Raid.Parties[0].Players[0].Glyphs) {
+							continue
+						}
+
 						sr.Raid.Parties[0].Players[0].TalentsString = talent.TalentsString
 						sr.Raid.Parties[0].Players[0].Glyphs = talent.Glyphs
 						cl.TalentLoadout = talent
@@ -395,7 +400,7 @@ func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []sin
 			cancel() // cancel reporter
 			return nil, nil, errors.New("simulation failed: " + result.Result.ErrorResult)
 		}
-		if !result.Substitution.HasItemReplacements() {
+		if !result.Substitution.HasItemReplacements() && result.ChangeLog.TalentLoadout == nil {
 			baseResult = result
 		}
 		rankedResults[i] = result

--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -98,6 +98,7 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 
 	// Gemming for now can happen before slots are decided.
 	// We might have to add logic after slot decisions if we want to enforce keeping meta gem active.
+
 	if b.Request.BulkSettings.AutoGem {
 		for _, replaceItem := range b.Request.BulkSettings.Items {
 			itemData := ItemsByID[replaceItem.Id]
@@ -184,7 +185,25 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 		}
 		substitutedRequest, changeLog := createNewRequestWithSubstitution(b.Request.BaseSettings, sub, b.Request.BulkSettings.AutoEnchant)
 		if isValidEquipment(substitutedRequest.Raid.Parties[0].Players[0].Equipment) {
+			// Need to sim base dps of gear loudout
 			validCombos = append(validCombos, singleBulkSim{req: substitutedRequest, cl: changeLog, eq: sub})
+			// Todo(Netzone-GehennasEU): Make this its own step?
+			if !b.Request.BulkSettings.SimTalents {
+
+			} else {
+				var talentsToSim = b.Request.BulkSettings.GetTalentsToSim()
+
+				if len(talentsToSim) > 0 {
+					for _, talent := range talentsToSim {
+						sr := goproto.Clone(substitutedRequest).(*proto.RaidSimRequest)
+						cl := *changeLog
+						sr.Raid.Parties[0].Players[0].TalentsString = talent.TalentsString
+						sr.Raid.Parties[0].Players[0].Glyphs = talent.Glyphs
+						cl.TalentLoadout = talent
+						validCombos = append(validCombos, singleBulkSim{req: sr, cl: &cl, eq: sub})
+					}
+				}
+			}
 		}
 	}
 
@@ -275,10 +294,10 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 		um.Auras = nil
 		um.Resources = nil
 		um.Pets = nil
-
 		result.Results = append(result.Results, &proto.BulkComboResult{
-			ItemsAdded:  r.ChangeLog.AddedItems,
-			UnitMetrics: um,
+			ItemsAdded:    r.ChangeLog.AddedItems,
+			UnitMetrics:   um,
+			TalentLoadout: r.ChangeLog.TalentLoadout,
 		})
 	}
 
@@ -337,6 +356,7 @@ func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []sin
 		for _, singleCombo := range validCombos {
 			<-tickets
 			singleSimProgress := make(chan *proto.ProgressMetrics)
+
 			// watches this progress and pushes up to main reporter.
 			go func(prog chan *proto.ProgressMetrics) {
 				var prevDone int32
@@ -352,6 +372,7 @@ func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []sin
 			// actually run the sim in here.
 			go func(sub singleBulkSim) {
 				// overwrite the requests iterations with the input for this function.
+
 				sub.req.SimOptions.Iterations = int32(iterations)
 				results <- &itemSubstitutionSimResult{
 					Request:      sub.req,
@@ -620,7 +641,8 @@ type itemWithSlot struct {
 // raidSimRequestChangeLog stores a change log of which items were added and removed from the base
 // equipment set.
 type raidSimRequestChangeLog struct {
-	AddedItems []*proto.ItemSpecWithSlot
+	AddedItems    []*proto.ItemSpecWithSlot
+	TalentLoadout *proto.TalentLoadout
 }
 
 // createNewRequestWithSubstitution creates a copy of the input RaidSimRequest and applis the given

--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"reflect"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -198,7 +197,7 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 					for _, talent := range talentsToSim {
 						sr := goproto.Clone(substitutedRequest).(*proto.RaidSimRequest)
 						cl := *changeLog
-						if sr.Raid.Parties[0].Players[0].TalentsString == talent.TalentsString && reflect.DeepEqual(talent.Glyphs, sr.Raid.Parties[0].Players[0].Glyphs) {
+						if sr.Raid.Parties[0].Players[0].TalentsString == talent.TalentsString && goproto.Equal(talent.Glyphs, sr.Raid.Parties[0].Players[0].Glyphs) {
 							continue
 						}
 

--- a/ui/core/components/individual_sim_ui/bulk_tab.ts
+++ b/ui/core/components/individual_sim_ui/bulk_tab.ts
@@ -82,14 +82,17 @@ class BulkSimResultRenderer {
 		parent.bodyElement.appendChild(itemsContainer);
 		parent.bodyElement.appendChild(dpsDivParent);
 
+		const talentText = document.createElement('p');
+		talentText.classList.add('talent-loadout-text')
 		if (result.talentLoadout && typeof result.talentLoadout === 'object') {
-			const talentText = document.createElement('p');
 			if (typeof result.talentLoadout.name === 'string') {
 				talentText.textContent = 'Talent loadout used: ' + result.talentLoadout.name;
 			}
-			parent.bodyElement.appendChild(talentText);
+		} else {
+			talentText.textContent = 'Current talents'
 		}
 
+		dpsDiv.appendChild(talentText);
 		if (result.itemsAdded && result.itemsAdded.length > 0) {
 			const equipBtn = document.createElement('button');
 			equipBtn.textContent = 'Equip';

--- a/ui/core/components/individual_sim_ui/bulk_tab.ts
+++ b/ui/core/components/individual_sim_ui/bulk_tab.ts
@@ -8,7 +8,7 @@ import { TypedEvent } from "../../typed_event";
 import { EventID } from '../../typed_event.js';
 
 import { BulkComboResult, BulkSettings, ItemSpecWithSlot, ProgressMetrics, TalentLoadout } from "../../proto/api";
-import { EquipmentSpec, Faction, GemColor, ItemSlot, ItemSpec, SimDatabase, SimEnchant, SimGem, SimItem, Spec } from "../../proto/common";
+import { EquipmentSpec, Faction, GemColor, Glyphs, ItemSlot, ItemSpec, SimDatabase, SimEnchant, SimGem, SimItem, Spec } from "../../proto/common";
 
 import { ItemData, ItemList, ItemRenderer, SelectorModal, SelectorModalTabs } from "../gear_picker";
 import { SimTab } from "../sim_tab";
@@ -712,10 +712,9 @@ export class BulkTab extends SimTab {
 				let index = this.savedTalents.findIndex(talent => JSON.stringify(talent) === JSON.stringify(loadout));
 				const talentFragment = document.createElement('fragment');
 				talentFragment.innerHTML = `
-            <div class="saved-data-set-chip badge rounded-pill ${index !== -1 ? 'active' : ''}">
-                <a href="javascript:void(0)" class="saved-data-set-name" role="button">${name}</a>
-            </div>
-        `;
+					<div class="saved-data-set-chip badge rounded-pill ${index !== -1 ? 'active' : ''}">
+						<a href="javascript:void(0)" class="saved-data-set-name" role="button">${name}</a>
+					</div>`;
 
 				console.log("Adding event for loadout", loadout);
 				// Wrap the event listener addition in an IIFE

--- a/ui/core/components/individual_sim_ui/bulk_tab.ts
+++ b/ui/core/components/individual_sim_ui/bulk_tab.ts
@@ -7,13 +7,13 @@ import { TypedEvent } from "../../typed_event";
 
 import { EventID } from '../../typed_event.js';
 
-import { BulkComboResult, BulkSettings, ItemSpecWithSlot, ProgressMetrics } from "../../proto/api";
+import { BulkComboResult, BulkSettings, ItemSpecWithSlot, ProgressMetrics, TalentLoadout } from "../../proto/api";
 import { EquipmentSpec, Faction, GemColor, ItemSlot, ItemSpec, SimDatabase, SimEnchant, SimGem, SimItem, Spec } from "../../proto/common";
 
 import { ItemData, ItemList, ItemRenderer, SelectorModal, SelectorModalTabs } from "../gear_picker";
 import { SimTab } from "../sim_tab";
 
-import { UIEnchant, UIGem, UIItem } from "../../proto/ui";
+import { SavedTalents, UIEnchant, UIGem, UIItem } from "../../proto/ui";
 import { EquippedItem } from "../../proto_utils/equipped_item";
 import { Component } from "../component";
 import { ResultsViewer } from "../results_viewer";
@@ -50,6 +50,7 @@ export class BulkGearJsonImporter<SpecType extends Spec> extends Importer {
 			}
 			this.close();
 		} catch (e: any) {
+			console.warn(e);
 			alert(e.toString());
 		}
 	}
@@ -81,6 +82,14 @@ class BulkSimResultRenderer {
 		parent.bodyElement.appendChild(itemsContainer);
 		parent.bodyElement.appendChild(dpsDivParent);
 
+		if (result.talentLoadout && typeof result.talentLoadout === 'object') {
+			const talentText = document.createElement('p');
+			if (typeof result.talentLoadout.name === 'string') {
+				talentText.textContent = 'Talent loadout used: ' + result.talentLoadout.name;
+			}
+			parent.bodyElement.appendChild(talentText);
+		}
+
 		if (result.itemsAdded && result.itemsAdded.length > 0) {
 			const equipBtn = document.createElement('button');
 			equipBtn.textContent = 'Equip';
@@ -105,7 +114,7 @@ class BulkSimResultRenderer {
 				p.textContent = this.itemSlotName(is);
 				renderer.nameElem.appendChild(p);
 			}
-		} else {
+		} else if (!result.talentLoadout || typeof result.talentLoadout !== 'object') {
 			const p = document.createElement('p');
 			p.textContent = 'No changes - this is your currently equipped gear!';
 			parent.bodyElement.appendChild(p);
@@ -228,8 +237,10 @@ export class BulkTab extends SimTab {
 	private doCombos: boolean;
 	private fastMode: boolean;
 	private autoGem: boolean;
+	private simTalents: boolean;
 	private autoEnchant: boolean;
 	private defaultGems: SimGem[];
+	private savedTalents: TalentLoadout[];
 	private gemIconElements: HTMLImageElement[];
 
 	constructor(parentElem: HTMLElement, simUI: IndividualSimUI<Spec>) {
@@ -256,6 +267,8 @@ export class BulkTab extends SimTab {
 		this.fastMode = true;
 		this.autoGem = true;
 		this.autoEnchant = true;
+		this.savedTalents = [];
+		this.simTalents = false;
 		this.defaultGems = [UIGem.create(), UIGem.create(), UIGem.create(), UIGem.create()];
 		this.gemIconElements = [];
 		this.buildTabContent();
@@ -277,7 +290,9 @@ export class BulkTab extends SimTab {
 			this.doCombos = settings.combinations;
 			this.fastMode = settings.fastMode;
 			this.autoEnchant = settings.autoEnchant;
+			this.savedTalents = settings.talentsToSim;
 			this.autoGem = settings.autoGem;
+			this.simTalents = settings.simTalents;
 			this.defaultGems = new Array<SimGem>(
 				SimGem.create({ id: settings.defaultRedGem }),
 				SimGem.create({ id: settings.defaultYellowGem }),
@@ -311,6 +326,8 @@ export class BulkTab extends SimTab {
 			fastMode: this.fastMode,
 			autoEnchant: this.autoEnchant,
 			autoGem: this.autoGem,
+			simTalents: this.simTalents,
+			talentsToSim: this.savedTalents,
 			defaultRedGem: this.defaultGems[0].id,
 			defaultYellowGem: this.defaultGems[1].id,
 			defaultBlueGem: this.defaultGems[2].id,
@@ -641,6 +658,82 @@ export class BulkTab extends SimTab {
 		});
 		settingsBlock.bodyElement.appendChild(clearButton);
 
+		// Talents to sim
+		const talentsToSimDiv = document.createElement("div")
+		if (this.simTalents) {
+			talentsToSimDiv.style.display = "flex";
+		} else {
+			talentsToSimDiv.style.display = "none";
+		}
+		talentsToSimDiv.classList.add("talents-picker-container")
+		const talentsLabel = document.createElement("label")
+		talentsLabel.innerText = "Pick talents to sim (will increase time to sim)";
+		talentsToSimDiv.appendChild(talentsLabel);
+		const talentsContainerDiv = document.createElement("div");
+		talentsContainerDiv.classList.add("talents-container");
+
+		const dataStr = window.localStorage.getItem(this.simUI.getSavedTalentsStorageKey());
+
+		let jsonData;
+		try {
+			if (dataStr !== null) {
+				jsonData = JSON.parse(dataStr);
+			}
+		} catch (e) {
+			console.warn('Invalid json for local storage value: ' + dataStr);
+		}
+		const handleToggle = (frag: HTMLElement, load: TalentLoadout) => {
+			let chipDiv = frag.querySelector('.saved-data-set-chip');
+			let exists = this.savedTalents.some(talent => talent.name === load.name); // Replace 'id' with your unique identifier
+
+			console.log('Exists:', exists);
+			console.log('Load Object:', load);
+			console.log('Saved Talents Before Update:', this.savedTalents);
+
+			if (exists) {
+				// If the object exists, find its index and remove it
+				let indexToRemove = this.savedTalents.findIndex(talent => talent.name === load.name);
+				this.savedTalents.splice(indexToRemove, 1);
+				chipDiv?.classList.remove('active');
+			} else {
+				// If the object does not exist, add it
+				this.savedTalents.push(load);
+				chipDiv?.classList.add('active');
+			}
+
+			console.log('Updated savedTalents:', this.savedTalents);
+		}
+		for (let name in jsonData) {
+			try {
+				console.log(name, jsonData[name]);
+				let savedTalentLoadout = SavedTalents.fromJson(jsonData[name]);
+				var loadout = { talentsString: savedTalentLoadout.talentsString, glyphs: savedTalentLoadout.glyphs, name: name };
+
+				let index = this.savedTalents.findIndex(talent => JSON.stringify(talent) === JSON.stringify(loadout));
+				const talentFragment = document.createElement('fragment');
+				talentFragment.innerHTML = `
+            <div class="saved-data-set-chip badge rounded-pill ${index !== -1 ? 'active' : ''}">
+                <a href="javascript:void(0)" class="saved-data-set-name" role="button">${name}</a>
+            </div>
+        `;
+
+				console.log("Adding event for loadout", loadout);
+				// Wrap the event listener addition in an IIFE
+				(function (talentFragment, loadout) {
+					talentFragment.addEventListener("click", () => handleToggle(talentFragment, loadout));
+				})(talentFragment, loadout);
+
+				talentsContainerDiv.appendChild(talentFragment);
+			} catch (e) {
+				console.log(e);
+				console.warn('Failed parsing saved data: ' + jsonData[name]);
+			}
+		}
+
+		talentsToSimDiv.append(talentsContainerDiv);
+		//////////////////////
+		////////////////////////////////////
+
 		// Default Gem Options
 		const defaultGemDiv = document.createElement("div");
 		if (this.autoGem) {
@@ -740,7 +833,23 @@ export class BulkTab extends SimTab {
 			}
 		});
 
+		new BooleanPicker<BulkTab>(settingsBlock.bodyElement, this, {
+			label: "Sim Talents",
+			labelTooltip: "When checked bulk simulator will sim chosen talent setups. Warning, it might cause the bulk sim to run for a lot longer",
+			changedEvent: (obj: BulkTab) => this.itemsChangedEmitter,
+			getValue: (obj) => this.simTalents,
+			setValue: (id: EventID, obj: BulkTab, value: boolean) => {
+				obj.simTalents = value
+				if (value) {
+					talentsToSimDiv.style.display = "flex";
+				} else {
+					talentsToSimDiv.style.display = "none";
+				}
+			}
+		});
+
 		settingsBlock.bodyElement.appendChild(defaultGemDiv);
+		settingsBlock.bodyElement.appendChild(talentsToSimDiv);
 	}
 
 	private setSimProgress(progress: ProgressMetrics, iterPerSecond: number, currentRound: number, rounds: number, combinations: number) {

--- a/ui/scss/core/components/_bulk.scss
+++ b/ui/scss/core/components/_bulk.scss
@@ -153,6 +153,10 @@
     }
   }
 
+  .talent-loadout-text {
+    font-size: smaller;
+  }
+
   .talents-picker-container {
     display: flex;
     flex-direction: column;

--- a/ui/scss/core/components/_bulk.scss
+++ b/ui/scss/core/components/_bulk.scss
@@ -6,17 +6,19 @@
 
 .bulk-result {
   margin-bottom: 0.5rem;
+
   .bulk-equipit {
     height: 40px;
     flex: 1;
   }
+
   .bulk-results-body {
     flex-direction: row;
   }
 }
 
 .bulk-result-item-slot {
-  color:aliceblue;
+  color: aliceblue;
   margin-left: 0.5rem;
   font-size: 0.5 * map.get($font-sizes, 6);
 }
@@ -25,7 +27,8 @@
   border-bottom: none;
 }
 
-.bulk-result-header-positive, .bulk-result-header-negative {
+.bulk-result-header-positive,
+.bulk-result-header-negative {
   font-weight: bold;
   margin-left: 0.5rem;
 }
@@ -60,6 +63,7 @@
   grid-template-columns: repeat(3, 32%);
   grid-template-rows: auto;
   flex: 5;
+
   .item-picker-root {
     padding: 2px;
   }
@@ -90,9 +94,9 @@
   align-items: center;
   justify-content: center;
   z-index: 1;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0, 0, 0, 0.5);
   max-height: 100vh;
-  
+
   .results-content {
     .results-sim {
       div {
@@ -120,6 +124,7 @@
       margin-top: 5px;
       border-bottom: 1px solid white;
       padding: 3px;
+
       label {
         flex: 1;
       }
@@ -133,16 +138,29 @@
       display: flex;
     }
   }
-  
+
   .batch-search-results {
     list-style: none;
-    background: rgba(0,0,0,0.3);
+    background: rgba(0, 0, 0, 0.3);
+
     li {
       cursor: pointer;
       background: transparent;
+
       &:hover {
-        background: rgba(255,255,255, 0.3);
+        background: rgba(255, 255, 255, 0.3);
       }
+    }
+  }
+
+  .talents-picker-container {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid white;
+    padding-bottom: 5px;
+
+    .talents-container {
+      display: flex;
     }
   }
 
@@ -151,7 +169,7 @@
     flex-direction: column;
     border-bottom: 1px solid white;
     padding-bottom: 5px;
-    
+
     .gem-socket-container {
       height: 40px;
       width: 40px;


### PR DESCRIPTION
Sorry if I'm making a mess, first time contributing, looking for feedback.

I thought about where to put the talent sims. My use case would be for example simming two set bonuses against eachother, but the set bonus requires a talent swap to maximise the dps.

So for now I've put it in the loop where we add the valid sims. There's still some issues, mainly in the GUI and we sim unnecessary talent loadouts right now. We shouldn't have to sim the currently loaded talent spec even if you pick it, because the bulksim does that automatically.

I think it's also important to note that this obviously multiplies the amount of sims that are needed for a result and so it only does the sims when activated. 

It's not very nicely visualised in the UI either, and you probably want to equip the talent loadout as well on the button press.