### PR TITLE
Fix hunter 4pT10 AP multiplier

### DIFF
--- a/sim/hunter/wotlk_items.go
+++ b/sim/hunter/wotlk_items.go
@@ -177,8 +177,8 @@ var ItemSetAhnKaharBloodHuntersBattlegear = core.NewItemSet(core.ItemSet{
 				Duration: time.Second * 10,
 				OnGain: func(aura *core.Aura, sim *core.Simulation) {
 					curBonus = stats.Stats{
-						stats.AttackPower:       aura.Unit.GetStat(stats.AttackPower) * 0.1,
-						stats.RangedAttackPower: aura.Unit.GetStat(stats.RangedAttackPower) * 0.1,
+						stats.AttackPower:       aura.Unit.GetStat(stats.AttackPower) * 0.2,
+						stats.RangedAttackPower: aura.Unit.GetStat(stats.RangedAttackPower) * 0.2,
 					}
 
 					aura.Unit.AddStatsDynamic(sim, curBonus)


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/cfaef76d-1a23-4b53-a860-225b3affadd9)
According to the databse, hunter's 4pT10 bonus should gain 20% AP instead of 10%. 

This can be verified in WCL log https://classic.warcraftlogs.com/reports/6NWxBQbwMrtvqcX8?fight=11&type=resources&source=38&view=events&spell=1001 at 0:35 the first proc of 4pT10, AP increased from `10288` to `12345`, with delta of `12345-10288 = 2057` which is roughly `2057/10288=19.9999%`

## Result

![image](https://github.com/user-attachments/assets/39e1ff34-03e8-40ef-bb4a-e80bbfbb7c42)

with preset config and p4 preset
 