### PR TITLE
Add Maghia's Misguided Quill to Affliction APL

### DIFF
--- a/ui/warlock/apls/affliction.apl.json
+++ b/ui/warlock/apls/affliction.apl.json
@@ -1,54 +1,336 @@
 {
-    "type": "TypeAPL",
-    "prepullActions": [
-        {"action":{"triggerIcd":{"auraId":{"spellId":71636}}},"doAtValue":{"const":{"val":"-105s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":72416}}},"doAtValue":{"const":{"val":"-65s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":55637}}},"doAtValue":{"const":{"val":"-65s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":75473}}},"doAtValue":{"const":{"val":"-55s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":64713}}},"doAtValue":{"const":{"val":"-50s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":60492}}},"doAtValue":{"const":{"val":"-50s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":60064}}},"doAtValue":{"const":{"val":"-50s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":64741}}},"doAtValue":{"const":{"val":"-50s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":60494}}},"doAtValue":{"const":{"val":"-50s"}}},
-        {"action":{"triggerIcd":{"auraId":{"spellId":67669}}},"doAtValue":{"const":{"val":"-50s"}}},
-        {"action":{"triggerIcd":{"auraId":{"itemId":50348}}},"doAtValue":{"const":{"val":"-50s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-23s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-21s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-19s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-17s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-15s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-13s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-11s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-9s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-7s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}},"doAtValue":{"const":{"val":"-4.5s"}}},
-        {"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAtValue":{"const":{"val":"-1.65s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":47809}}},"doAtValue":{"const":{"val":"-1.65s"}}}
-    ],
-    "priorityList": [
-        {"action":{"condition":{"cmp":{"op":"OpGe","lhs":{"currentTime":{}},"rhs":{"const":{"val":"0"}}}},"castSpell":{"spellId":{"spellId":2825,"tag":-1}}}},
-        {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":70840}}},"sequence":{"name":"tricks","actions":[{"castSpell":{"spellId":{"spellId":57933,"tag":-1}}},{"castSpell":{"spellId":{"itemId":50259}}}]}}},
-        {"action":{"condition":{"isExecutePhase":{"threshold":"E35"}},"resetSequence":{"sequenceName":"tricks"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":10060,"tag":-1}}}},
-        {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":70840}}},"castSpell":{"spellId":{"itemId":50259}}}},
-        {"action":{"condition":{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"138"}}}}]}},"castSpell":{"spellId":{"itemId":45466}}}},
-        {"action":{"condition":{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"138"}}}}]}},"castSpell":{"spellId":{"spellId":33697}}}},
-        {"action":{"condition":{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"138"}}}}]}},"castSpell":{"spellId":{"itemId":45148}}}},
-        {"action":{"condition":{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"138"}}}}]}},"castSpell":{"spellId":{"itemId":48722}}}},
-        {"action":{"condition":{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"70"}}}}]}},"castSpell":{"spellId":{"spellId":54758}}}},
-        {"action":{"condition":{"or":{"vals":[{"and":{"vals":[{"isExecutePhase":{"threshold":"E25"}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":64713}}},{"auraIsActive":{"auraId":{"itemId":50348}}},{"auraIsActive":{"auraId":{"spellId":71636}}},{"auraIsActive":{"auraId":{"spellId":60492}}},{"auraIsActive":{"auraId":{"spellId":60064}}},{"auraIsActive":{"auraId":{"spellId":64741}}},{"auraIsActive":{"auraId":{"spellId":60494}}},{"auraIsActive":{"auraId":{"spellId":67669}}},{"auraIsActive":{"auraId":{"spellId":75473}}}]}}]}},{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"25"}}}}]}},"sequence":{"name":"big snap","actions":[{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},{"castSpell":{"spellId":{"itemId":45466}}},{"castSpell":{"spellId":{"spellId":33697}}},{"castSpell":{"spellId":{"spellId":54758}}},{"castSpell":{"spellId":{"itemId":45148}}},{"castSpell":{"spellId":{"itemId":48722}}}]}}},
-        {"action":{"sequence":{"name":"opener","actions":[{"castSpell":{"spellId":{"spellId":47813}}},{"castSpell":{"spellId":{"spellId":59164}}},{"castSpell":{"spellId":{"spellId":47843}}},{"castSpell":{"spellId":{"spellId":47864}}}]}}},
-        {"action":{"condition":{"and":{"vals":[{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":71572}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellCastTime":{"spellId":{"spellId":59164}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellTravelTime":{"spellId":{"spellId":59164}}},"rhs":{"const":{"val":"2"}}}}}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":60486}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellCastTime":{"spellId":{"spellId":59164}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellTravelTime":{"spellId":{"spellId":59164}}},"rhs":{"const":{"val":"2"}}}}}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":65006}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellCastTime":{"spellId":{"spellId":59164}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellTravelTime":{"spellId":{"spellId":59164}}},"rhs":{"const":{"val":"2"}}}}}}}}]}},{"isExecutePhase":{"threshold":"E25"}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"5"}}}}]}},"castSpell":{"spellId":{"spellId":59164}}}},
-        {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":59164}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellCastTime":{"spellId":{"spellId":59164}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellTravelTime":{"spellId":{"spellId":59164}}},"rhs":{"const":{"val":"2"}}}}}}}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"5"}}}}]}},"castSpell":{"spellId":{"spellId":59164}}}},
-        {"action":{"condition":{"and":{"vals":[{"or":{"vals":[{"not":{"val":{"auraIsActive":{"auraId":{"spellId":63321}}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":63321}}},"rhs":{"const":{"val":"2"}}}}]}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"27"}}}}]}},"castSpell":{"spellId":{"spellId":57946}}}},
-        {"action":{"condition":{"warlockShouldRefreshCorruption":{}},"castSpell":{"spellId":{"spellId":47813}}}},
-        {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLt","lhs":{"dotRemainingTime":{"spellId":{"spellId":47843}}},"rhs":{"spellCastTime":{"spellId":{"spellId":47843}}}}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"10"}}}}]}},"castSpell":{"spellId":{"spellId":47843}}}},
-        {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"64"}}}},"castSpell":{"spellId":{"spellId":1122}}}},
-        {"action":{"condition":{"and":{"vals":[{"not":{"val":{"dotIsActive":{"spellId":{"spellId":47864}}}}},{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"22"}}}}]}},"castSpell":{"spellId":{"spellId":47864}}}},
-        {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLt","lhs":{"remainingTimePercent":{}},"rhs":{"const":{"val":"27%"}}}},{"not":{"val":{"isExecutePhase":{"threshold":"E25"}}}}]}},"sequence":{"name":"lifetap","actions":[{"castSpell":{"spellId":{"spellId":57946}}}]}}},
-        {"action":{"condition":{"warlockShouldRecastDrainSoul":{}},"channelSpell":{"spellId":{"spellId":47855},"interruptIf":{}}}},
-        {"action":{"condition":{"isExecutePhase":{"threshold":"E25"}},"channelSpell":{"spellId":{"spellId":47855},"interruptIf":{"const":{"val":"True"}}}}},
-        {"action":{"castSpell":{"spellId":{"spellId":47809}}}},
-        {"action":{"castSpell":{"spellId":{"spellId":57946}}}}
-    ]
+	"type": "TypeAPL",
+	"prepullActions": [
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 71636 } } }, "doAtValue": { "const": { "val": "-105s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 72416 } } }, "doAtValue": { "const": { "val": "-65s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 55637 } } }, "doAtValue": { "const": { "val": "-65s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 75473 } } }, "doAtValue": { "const": { "val": "-55s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 64713 } } }, "doAtValue": { "const": { "val": "-50s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 60492 } } }, "doAtValue": { "const": { "val": "-50s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 60064 } } }, "doAtValue": { "const": { "val": "-50s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 64741 } } }, "doAtValue": { "const": { "val": "-50s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 60494 } } }, "doAtValue": { "const": { "val": "-50s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "spellId": 67669 } } }, "doAtValue": { "const": { "val": "-50s" } } },
+		{ "action": { "triggerIcd": { "auraId": { "itemId": 50348 } } }, "doAtValue": { "const": { "val": "-50s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-23s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-21s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-19s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-17s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-15s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-13s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-11s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-9s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-7s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } }, "doAtValue": { "const": { "val": "-4.5s" } } },
+		{ "action": { "castSpell": { "spellId": { "otherId": "OtherActionPotion" } } }, "doAtValue": { "const": { "val": "-1.65s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 47809 } } }, "doAtValue": { "const": { "val": "-1.65s" } } }
+	],
+	"priorityList": [
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpGe", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "0" } } } },
+				"castSpell": { "spellId": { "spellId": 2825, "tag": -1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "auraIsActive": { "auraId": { "spellId": 70840 } } },
+				"sequence": {
+					"name": "tricks",
+					"actions": [{ "castSpell": { "spellId": { "spellId": 57933, "tag": -1 } } }, { "castSpell": { "spellId": { "itemId": 50259 } } }]
+				}
+			}
+		},
+		{ "action": { "condition": { "isExecutePhase": { "threshold": "E35" } }, "resetSequence": { "sequenceName": "tricks" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 10060, "tag": -1 } } } },
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 70840 } } }, "castSpell": { "spellId": { "itemId": 50259 } } } },
+		{
+			"action": {
+				"condition": { "or": { "vals": [{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "138" } } } }] } },
+				"castSpell": { "spellId": { "itemId": 45466 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "or": { "vals": [{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "138" } } } }] } },
+				"castSpell": { "spellId": { "spellId": 33697 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "or": { "vals": [{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "138" } } } }] } },
+				"castSpell": { "spellId": { "itemId": 45148 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "or": { "vals": [{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "138" } } } }] } },
+				"castSpell": { "spellId": { "itemId": 48722 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "or": { "vals": [{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "138" } } } }] } },
+				"castSpell": { "spellId": { "itemId": 50357 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "or": { "vals": [{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "70" } } } }] } },
+				"castSpell": { "spellId": { "spellId": 54758 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"or": {
+						"vals": [
+							{
+								"and": {
+									"vals": [
+										{ "isExecutePhase": { "threshold": "E25" } },
+										{
+											"or": {
+												"vals": [
+													{ "auraIsActive": { "auraId": { "spellId": 64713 } } },
+													{ "auraIsActive": { "auraId": { "itemId": 50348 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 71636 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 60492 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 60064 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 64741 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 60494 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 67669 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 75473 } } }
+												]
+											}
+										}
+									]
+								}
+							},
+							{ "cmp": { "op": "OpLe", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "25" } } } }
+						]
+					}
+				},
+				"sequence": {
+					"name": "big snap",
+					"actions": [
+						{ "castSpell": { "spellId": { "otherId": "OtherActionPotion" } } },
+						{ "castSpell": { "spellId": { "itemId": 45466 } } },
+						{ "castSpell": { "spellId": { "spellId": 33697 } } },
+						{ "castSpell": { "spellId": { "spellId": 54758 } } },
+						{ "castSpell": { "spellId": { "itemId": 45148 } } },
+						{ "castSpell": { "spellId": { "itemId": 48722 } } },
+						{ "castSpell": { "spellId": { "itemId": 50357 } } }
+					]
+				}
+			}
+		},
+		{
+			"action": {
+				"sequence": {
+					"name": "opener",
+					"actions": [
+						{ "castSpell": { "spellId": { "spellId": 47813 } } },
+						{ "castSpell": { "spellId": { "spellId": 59164 } } },
+						{ "castSpell": { "spellId": { "spellId": 47843 } } },
+						{ "castSpell": { "spellId": { "spellId": 47864 } } }
+					]
+				}
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{
+								"or": {
+									"vals": [
+										{
+											"cmp": {
+												"op": "OpLt",
+												"lhs": { "auraRemainingTime": { "auraId": { "spellId": 71572 } } },
+												"rhs": {
+													"math": {
+														"op": "OpAdd",
+														"lhs": { "spellCastTime": { "spellId": { "spellId": 59164 } } },
+														"rhs": {
+															"math": {
+																"op": "OpAdd",
+																"lhs": { "spellTravelTime": { "spellId": { "spellId": 59164 } } },
+																"rhs": { "const": { "val": "2" } }
+															}
+														}
+													}
+												}
+											}
+										},
+										{
+											"cmp": {
+												"op": "OpLt",
+												"lhs": { "auraRemainingTime": { "auraId": { "spellId": 60486 } } },
+												"rhs": {
+													"math": {
+														"op": "OpAdd",
+														"lhs": { "spellCastTime": { "spellId": { "spellId": 59164 } } },
+														"rhs": {
+															"math": {
+																"op": "OpAdd",
+																"lhs": { "spellTravelTime": { "spellId": { "spellId": 59164 } } },
+																"rhs": { "const": { "val": "2" } }
+															}
+														}
+													}
+												}
+											}
+										},
+										{
+											"cmp": {
+												"op": "OpLt",
+												"lhs": { "auraRemainingTime": { "auraId": { "spellId": 65006 } } },
+												"rhs": {
+													"math": {
+														"op": "OpAdd",
+														"lhs": { "spellCastTime": { "spellId": { "spellId": 59164 } } },
+														"rhs": {
+															"math": {
+																"op": "OpAdd",
+																"lhs": { "spellTravelTime": { "spellId": { "spellId": 59164 } } },
+																"rhs": { "const": { "val": "2" } }
+															}
+														}
+													}
+												}
+											}
+										}
+									]
+								}
+							},
+							{ "isExecutePhase": { "threshold": "E25" } },
+							{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "5" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 59164 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{
+								"cmp": {
+									"op": "OpLt",
+									"lhs": { "auraRemainingTime": { "sourceUnit": { "type": "CurrentTarget" }, "auraId": { "spellId": 59164 } } },
+									"rhs": {
+										"math": {
+											"op": "OpAdd",
+											"lhs": { "spellCastTime": { "spellId": { "spellId": 59164 } } },
+											"rhs": {
+												"math": {
+													"op": "OpAdd",
+													"lhs": { "spellTravelTime": { "spellId": { "spellId": 59164 } } },
+													"rhs": { "const": { "val": "2" } }
+												}
+											}
+										}
+									}
+								}
+							},
+							{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "5" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 59164 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{
+								"or": {
+									"vals": [
+										{ "not": { "val": { "auraIsActive": { "auraId": { "spellId": 63321 } } } } },
+										{
+											"cmp": {
+												"op": "OpLt",
+												"lhs": { "auraRemainingTime": { "auraId": { "spellId": 63321 } } },
+												"rhs": { "const": { "val": "2" } }
+											}
+										}
+									]
+								}
+							},
+							{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "27" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 57946 } }
+			}
+		},
+		{ "action": { "condition": { "warlockShouldRefreshCorruption": {} }, "castSpell": { "spellId": { "spellId": 47813 } } } },
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{
+								"cmp": {
+									"op": "OpLt",
+									"lhs": { "dotRemainingTime": { "spellId": { "spellId": 47843 } } },
+									"rhs": { "spellCastTime": { "spellId": { "spellId": 47843 } } }
+								}
+							},
+							{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "10" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 47843 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpLe", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "64" } } } },
+				"castSpell": { "spellId": { "spellId": 1122 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "not": { "val": { "dotIsActive": { "spellId": { "spellId": 47864 } } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "22" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 47864 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpLt", "lhs": { "remainingTimePercent": {} }, "rhs": { "const": { "val": "27%" } } } },
+							{ "not": { "val": { "isExecutePhase": { "threshold": "E25" } } } }
+						]
+					}
+				},
+				"sequence": { "name": "lifetap", "actions": [{ "castSpell": { "spellId": { "spellId": 57946 } } }] }
+			}
+		},
+		{ "action": { "condition": { "warlockShouldRecastDrainSoul": {} }, "channelSpell": { "spellId": { "spellId": 47855 }, "interruptIf": {} } } },
+		{
+			"action": {
+				"condition": { "isExecutePhase": { "threshold": "E25" } },
+				"channelSpell": { "spellId": { "spellId": 47855 }, "interruptIf": { "const": { "val": "True" } } }
+			}
+		},
+		{ "action": { "castSpell": { "spellId": { "spellId": 47809 } } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57946 } } } }
+	]
 }


### PR DESCRIPTION
## Summary

`Maghia's Misguided Quill` is not working and has 0% uptime when simming Affliction because the trinket was missing in the APL. Affliction warlock seems to use the manual trinket control while demo/destro uses `autocastOtherCooldowns` . This is only reproducible with Affliction, other spec and talent work. 

- [ ] make the trinket active in sim (in priority list and bigsnap)
- [ ] reformat the APL

![38a8eacd94ad27b17882982f32985d6](https://github.com/user-attachments/assets/7636af77-50e6-40c8-980c-2bfe5eadfd3b)

## After the fix

Misguided Quill is the better Living Flame so the behavior should be identical

![image](https://github.com/user-attachments/assets/f5134aa0-6a4e-40bb-9f97-e7be62ecf579)

DPS gain (p4 default with trinket 2)

![image](https://github.com/user-attachments/assets/c6d9636a-deeb-4c20-830c-7a1c5b686c7d)

